### PR TITLE
feat(budgeting): set category goal targets via update_category

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,10 +40,15 @@ tasks:
     cmds:
       - uv run pytest
 
-  test:integration:
-    desc: "Run the integration tests"
+  test:eval:
+    desc: "Run LLM-driven evals (needs ANTHROPIC_API_KEY + YNAB_API_KEY; costs API tokens)"
     cmds:
-      - uv run pytest -m "integration"
+      - uv run pytest -m "eval"
+
+  test:integration:
+    desc: "Run the integration tests (excludes the costly LLM evals)"
+    cmds:
+      - uv run pytest -m "integration and not eval"
 
   test:all:
     desc: "Run all tests including integration tests"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,7 +41,7 @@ tasks:
       - uv run pytest
 
   test:eval:
-    desc: "Run LLM-driven evals (needs ANTHROPIC_API_KEY + YNAB_API_KEY; costs API tokens)"
+    desc: "Run LLM-driven evals (needs YNAB_API_KEY; messages-api also needs ANTHROPIC_API_KEY and costs API tokens; agent-sdk uses your Claude subscription)"
     cmds:
       - uv run pytest -m "eval"
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -29,6 +29,42 @@ Without the keys, the eval tests **skip** (they never fail for missing config).
 > ```
 > `EVAL_ANTHROPIC_API_KEY` wins over `ANTHROPIC_API_KEY` for the evals only.
 
+## Two drivers (`EVAL_DRIVER`)
+
+The eval can be driven two ways:
+
+| `EVAL_DRIVER`            | Auth                                   | Cost                                   |
+| ------------------------ | -------------------------------------- | -------------------------------------- |
+| `messages-api` (default) | Anthropic **Console API key**          | Bills API tokens per run               |
+| `agent-sdk`              | Your **Claude subscription** (Claude Agent SDK) | Draws against your subscription usage; no API balance |
+
+Both run the same `evals.json`, the same structural checks, and the same LLM
+judge — only the engine and billing differ.
+
+### Use your Claude subscription (no API credits)
+
+The `agent-sdk` driver uses the **Claude Agent SDK** (the Claude Code engine),
+authenticated by your Claude subscription — so it doesn't spend API credits.
+
+```bash
+# Make sure you're logged in to Claude Code (one-time):
+claude login          # or: export EVAL_CLAUDE_CODE_OAUTH_TOKEN=$(claude setup-token)
+
+export EVAL_DRIVER=agent-sdk
+uv run python evals/run_prompt.py "How much did I spend on dining last month?"
+task test:eval        # judge runs on the subscription too
+```
+
+Notes:
+- Needs the `claude` CLI installed and logged in (you already use it). The driver
+  blanks out `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_USE_BEDROCK`
+  for the subprocess so the subscription login is what's used — your shell's
+  `ANTHROPIC_API_KEY` (a Claude Code OAuth token) won't get in the way.
+- Subscription auth is intended for **interactive/personal** use and draws against
+  your plan's usage limits — not a separate API balance. Fine for your own evals;
+  don't ship a shared product on it.
+- Only `YNAB_API_KEY` is required for this driver (no Anthropic API key).
+
 ## Safety
 
 Scope is **read-only + dry-run**. The server defaults to
@@ -62,13 +98,16 @@ final answer.
 
 ## Knobs
 
-| Env var                  | Default                     | Purpose                                          |
-| ------------------------ | --------------------------- | ------------------------------------------------ |
-| `EVAL_ANTHROPIC_API_KEY` | falls back to `ANTHROPIC_API_KEY` | Console key for evals; wins over the shell var.  |
-| `EVAL_MODEL`             | `claude-sonnet-4-6`         | Model that drives the tools.                     |
-| `EVAL_JUDGE_MODEL`       | `claude-haiku-4-5-20251001` | Model that scores answers (test suite).          |
-| `EVAL_MCP_COMMAND`       | `<current python>`          | Server launch command.                           |
-| `EVAL_MCP_ARGS`          | `["-m", "mcp_ynab"]`        | Server launch args (JSON list).                  |
+| Env var                       | Default                     | Purpose                                          |
+| ----------------------------- | --------------------------- | ------------------------------------------------ |
+| `EVAL_DRIVER`                 | `messages-api`              | `messages-api` (API key) or `agent-sdk` (subscription). |
+| `EVAL_ANTHROPIC_API_KEY`      | falls back to `ANTHROPIC_API_KEY` | Console key for the `messages-api` driver; wins over the shell var. |
+| `EVAL_CLAUDE_CODE_OAUTH_TOKEN`| falls back to `claude` login | `agent-sdk` subscription token (`claude setup-token`). |
+| `EVAL_MODEL`                  | `claude-sonnet-4-6`         | Model that drives the tools.                     |
+| `EVAL_JUDGE_MODEL`            | `claude-haiku-4-5-20251001` | Model that scores answers (test suite).          |
+| `EVAL_MAX_TURNS`              | `12`                        | Agent-SDK driver: max agent turns per prompt.    |
+| `EVAL_MCP_COMMAND`            | `<current python>`          | Server launch command.                           |
+| `EVAL_MCP_ARGS`               | `["-m", "mcp_ynab"]`        | Server launch args (JSON list).                  |
 
 To eval the **installed** tool instead of the dev tree:
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -14,11 +14,20 @@ editable install on your checked-out branch) — not a globally installed
 1. Install dev deps (adds `anthropic`): `task deps` (or `uv sync`).
 2. Provide both keys, in your shell or a `.env` at the repo root:
    ```
-   ANTHROPIC_API_KEY=sk-ant-...
-   YNAB_API_KEY=...        # the budget this key points at is what gets read
+   ANTHROPIC_API_KEY=sk-ant-api...   # a Console API key
+   YNAB_API_KEY=...                  # the budget this key points at is what gets read
    ```
 
 Without the keys, the eval tests **skip** (they never fail for missing config).
+
+> **Heads-up — Claude Code users:** if your shell exports `ANTHROPIC_API_KEY`
+> as a Claude Code **OAuth token** (`sk-ant-oat...`), the Messages API rejects
+> it with `401 invalid x-api-key`. Don't fight your shell — set a dedicated
+> Console key that takes precedence and leaves Claude Code alone:
+> ```
+> export EVAL_ANTHROPIC_API_KEY=sk-ant-api...
+> ```
+> `EVAL_ANTHROPIC_API_KEY` wins over `ANTHROPIC_API_KEY` for the evals only.
 
 ## Safety
 
@@ -53,12 +62,13 @@ final answer.
 
 ## Knobs
 
-| Env var            | Default                          | Purpose                                  |
-| ------------------ | -------------------------------- | ---------------------------------------- |
-| `EVAL_MODEL`       | `claude-sonnet-4-6`              | Model that drives the tools.             |
-| `EVAL_JUDGE_MODEL` | `claude-haiku-4-5-20251001`      | Model that scores answers (test suite).  |
-| `EVAL_MCP_COMMAND` | `<current python>`               | Server launch command.                   |
-| `EVAL_MCP_ARGS`    | `["-m", "mcp_ynab"]`             | Server launch args (JSON list).          |
+| Env var                  | Default                     | Purpose                                          |
+| ------------------------ | --------------------------- | ------------------------------------------------ |
+| `EVAL_ANTHROPIC_API_KEY` | falls back to `ANTHROPIC_API_KEY` | Console key for evals; wins over the shell var.  |
+| `EVAL_MODEL`             | `claude-sonnet-4-6`         | Model that drives the tools.                     |
+| `EVAL_JUDGE_MODEL`       | `claude-haiku-4-5-20251001` | Model that scores answers (test suite).          |
+| `EVAL_MCP_COMMAND`       | `<current python>`          | Server launch command.                           |
+| `EVAL_MCP_ARGS`          | `["-m", "mcp_ynab"]`        | Server launch args (JSON list).                  |
 
 To eval the **installed** tool instead of the dev tree:
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,74 @@
+# LLM evals
+
+These exercise the server the way a real client does: launch `mcp-ynab` over
+the MCP **stdio** transport, let **Claude** use the **Code Mode** surface
+(`search` + `execute`, with YNAB reached as `ynab.read.*` / `ynab.write.*`
+Python), and check the result.
+
+They always run against the **development** server in the current venv (the
+editable install on your checked-out branch) — not a globally installed
+`mcp-ynab` — so this is how you validate changes before shipping.
+
+## Prerequisites
+
+1. Install dev deps (adds `anthropic`): `task deps` (or `uv sync`).
+2. Provide both keys, in your shell or a `.env` at the repo root:
+   ```
+   ANTHROPIC_API_KEY=sk-ant-...
+   YNAB_API_KEY=...        # the budget this key points at is what gets read
+   ```
+
+Without the keys, the eval tests **skip** (they never fail for missing config).
+
+## Safety
+
+Scope is **read-only + dry-run**. The server defaults to
+`code_mode_mutations_enabled=False`, so `ynab.write.*` is blocked by the runner
+(AST audit + fail-closed dispatch) and hidden from the Code Mode spec. Nothing
+these evals do can change your budget. (To validate a *write* end-to-end you'd
+need a separate, explicitly opted-in eval — see issue `mcp-ynab-ala`.)
+
+## Run the eval set
+
+```bash
+task test:eval
+# or directly:
+uv run pytest -m eval
+# one case:
+uv run pytest -m eval -k "Dining Spend"
+```
+
+`task test:integration` runs the regular integration tests and **excludes**
+these (they cost API tokens).
+
+## Run a single ad-hoc prompt
+
+```bash
+uv run python evals/run_prompt.py "How much did I spend on dining last month?"
+uv run python evals/run_prompt.py --model claude-opus-4-8 "Which categories are over budget?"
+```
+
+Prints the Code Mode tool calls (including the Python sent to `execute`) and the
+final answer.
+
+## Knobs
+
+| Env var            | Default                          | Purpose                                  |
+| ------------------ | -------------------------------- | ---------------------------------------- |
+| `EVAL_MODEL`       | `claude-sonnet-4-6`              | Model that drives the tools.             |
+| `EVAL_JUDGE_MODEL` | `claude-haiku-4-5-20251001`      | Model that scores answers (test suite).  |
+| `EVAL_MCP_COMMAND` | `<current python>`               | Server launch command.                   |
+| `EVAL_MCP_ARGS`    | `["-m", "mcp_ynab"]`             | Server launch args (JSON list).          |
+
+To eval the **installed** tool instead of the dev tree:
+
+```bash
+EVAL_MCP_COMMAND=mcp-ynab EVAL_MCP_ARGS='[]' uv run pytest -m eval
+```
+
+## Adding evals
+
+Add a case to `evals.json`. `read` tasks fetch and report data; set
+`expected_code_refs` to the `ynab.read.*` op(s) you expect in the executed code
+(any one is enough). `mutation` tasks are dry runs scored by the LLM judge only
+(write ops are hidden read-only, so there's nothing to assert structurally).

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "mcp-ynab",
+  "description": "LLM-driven evals. Each prompt is given to Claude with the mcp-ynab tools over the real MCP stdio transport. Scope is read-only + dry-run: no eval should perform a real YNAB write. See tests/integration/test_llm_evals.py.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "Dining Spend Last Month",
+      "prompt": "How much did I spend on dining last month?",
+      "expected_output": "Reports the total dining or restaurant category activity for last month, with enough context to identify the budget, category, month, and dollar amount used.",
+      "category": "read",
+      "expectations": []
+    },
+    {
+      "id": 2,
+      "name": "Uncategorized Transactions",
+      "prompt": "Show me the uncategorized transactions that still need cleanup.",
+      "expected_output": "Lists uncategorized transactions needing attention, including dates, payees, amounts, ids, and whether each transaction is approved.",
+      "category": "read",
+      "expectations": []
+    },
+    {
+      "id": 3,
+      "name": "Over Budget Categories",
+      "prompt": "Which categories are over budget this month?",
+      "expected_output": "Identifies categories with negative current-month balances or overspending, grouped or summarized clearly with category names and dollar amounts.",
+      "category": "read",
+      "expectations": []
+    },
+    {
+      "id": 4,
+      "name": "Cash Balance Summary",
+      "prompt": "What's my current cash balance across accounts?",
+      "expected_output": "Summarizes current cash or on-budget account balances and gives a total in dollars, excluding closed or deleted accounts when account status is available.",
+      "category": "read",
+      "expectations": []
+    },
+    {
+      "id": 5,
+      "name": "Recent Large Transactions",
+      "prompt": "What are my largest transactions from the last 30 days?",
+      "expected_output": "Returns the largest recent transactions with date, payee, category when available, amount, and transaction id so the user can inspect unusual spending.",
+      "category": "read",
+      "expectations": []
+    },
+    {
+      "id": 6,
+      "name": "Dry Run Grocery Categorization",
+      "prompt": "Categorize the five most recent uncategorized transactions as Groceries, but don't actually change anything.",
+      "expected_output": "Plans a dry-run bulk PATCH using SaveTransactionWithIdOrImportId entries for five transaction ids with the resolved Groceries category id, without performing a real write.",
+      "category": "mutation",
+      "expectations": []
+    },
+    {
+      "id": 7,
+      "name": "Dry Run Approve Last Week",
+      "prompt": "Approve every unapproved transaction from last week, but only show me what you would update.",
+      "expected_output": "Plans a dry-run bulk PATCH where each selected transaction payload contains its id and approved=true, and does not submit the mutation.",
+      "category": "mutation",
+      "expectations": []
+    },
+    {
+      "id": 8,
+      "name": "Dry Run Move Dining Money",
+      "prompt": "Move $50 from Dining Out to Groceries for this month as a dry run.",
+      "expected_output": "Describes the intended month-category updates needed to reduce Dining Out by $50 and increase Groceries by $50, including resolved category ids and final budgeted amounts when available, without applying the changes.",
+      "category": "mutation",
+      "expectations": []
+    },
+    {
+      "id": 9,
+      "name": "Dry Run Set Category Goal Target",
+      "prompt": "Without changing anything yet, tell me exactly which tool and arguments you would use to set the monthly goal target for my Groceries category to $200.",
+      "expected_output": "Identifies the update_category tool with a goal_target argument of 200 dollars (the server converts dollars to milliunits) for the resolved Groceries category, and explicitly does not apply the change.",
+      "category": "mutation",
+      "expectations": []
+    }
+  ]
+}

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "mcp-ynab",
-  "description": "LLM-driven evals. Each prompt is given to Claude with the mcp-ynab tools over the real MCP stdio transport. Scope is read-only + dry-run: no eval should perform a real YNAB write. See tests/integration/test_llm_evals.py.",
+  "description": "LLM-driven evals. Each prompt is given to Claude with the mcp-ynab tools over the real MCP stdio transport. The server runs in Code Mode (its default/target surface): the public tools are `search` + `execute`, and YNAB helpers are reached as `ynab.read.*` / `ynab.write.*` Python inside `execute`. Evals run read-only: code_mode_mutations_enabled defaults to False, so `ynab.write.*` is blocked server-side and hidden from the spec. `read` tasks fetch and report data; `mutation` tasks are dry runs — the model reads the relevant data and describes the change it would make without applying it. See tests/integration/test_llm_evals.py.",
   "evals": [
     {
       "id": 1,
@@ -46,7 +46,7 @@
       "id": 6,
       "name": "Dry Run Grocery Categorization",
       "prompt": "Categorize the five most recent uncategorized transactions as Groceries, but don't actually change anything.",
-      "expected_output": "Plans a dry-run bulk PATCH using SaveTransactionWithIdOrImportId entries for five transaction ids with the resolved Groceries category id, without performing a real write.",
+      "expected_output": "Identifies up to five recent uncategorized transactions (with dates/payees/amounts/ids) and clearly lays out the Groceries categorization it would apply to each, without performing a real write.",
       "category": "mutation",
       "expectations": []
     },
@@ -54,7 +54,7 @@
       "id": 7,
       "name": "Dry Run Approve Last Week",
       "prompt": "Approve every unapproved transaction from last week, but only show me what you would update.",
-      "expected_output": "Plans a dry-run bulk PATCH where each selected transaction payload contains its id and approved=true, and does not submit the mutation.",
+      "expected_output": "Identifies last week's unapproved transactions and states that it would mark each approved, listing the affected transactions, without submitting any change.",
       "category": "mutation",
       "expectations": []
     },
@@ -62,15 +62,15 @@
       "id": 8,
       "name": "Dry Run Move Dining Money",
       "prompt": "Move $50 from Dining Out to Groceries for this month as a dry run.",
-      "expected_output": "Describes the intended month-category updates needed to reduce Dining Out by $50 and increase Groceries by $50, including resolved category ids and final budgeted amounts when available, without applying the changes.",
+      "expected_output": "Explains the intended move of $50 from Dining Out to Groceries for the current month, including the resulting budgeted amounts when available, without applying the change.",
       "category": "mutation",
       "expectations": []
     },
     {
       "id": 9,
       "name": "Dry Run Set Category Goal Target",
-      "prompt": "Without changing anything yet, tell me exactly which tool and arguments you would use to set the monthly goal target for my Groceries category to $200.",
-      "expected_output": "Identifies the update_category tool with a goal_target argument of 200 dollars (the server converts dollars to milliunits) for the resolved Groceries category, and explicitly does not apply the change.",
+      "prompt": "Without changing anything yet, walk me through how you would set the monthly goal target for my Groceries category to $200.",
+      "expected_output": "Identifies the Groceries category from the budget and explains setting a recurring monthly target of $200 for it, without applying the change. A clear, correct plan is sufficient; the server is read-only so the write is not performed.",
       "category": "mutation",
       "expectations": []
     }

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "mcp-ynab",
-  "description": "LLM-driven evals. Each prompt is given to Claude with the mcp-ynab tools over the real MCP stdio transport. The server runs in Code Mode (its default/target surface): the public tools are `search` + `execute`, and YNAB helpers are reached as `ynab.read.*` / `ynab.write.*` Python inside `execute`. Evals run read-only: code_mode_mutations_enabled defaults to False, so `ynab.write.*` is blocked server-side and hidden from the spec. `read` tasks fetch and report data; `mutation` tasks are dry runs — the model reads the relevant data and describes the change it would make without applying it. See tests/integration/test_llm_evals.py.",
+  "description": "LLM-driven evals. Each prompt is given to Claude with the mcp-ynab tools over the real MCP stdio transport. The server runs in Code Mode (its default/target surface): the public tools are `search` + `execute`, and YNAB helpers are reached as `ynab.read.*` / `ynab.write.*` Python inside `execute`. Evals run read-only: code_mode_mutations_enabled defaults to False, so `ynab.write.*` is blocked server-side and hidden from the spec. `read` tasks fetch and report data; `mutation` tasks are dry runs — the model reads the relevant data and describes the change it would make without applying it. `expected_code_refs` (read tasks) lists read operations whose presence in the executed Python is an acceptable structural signal; the test passes if ANY appears. See tests/integration/test_llm_evals.py.",
   "evals": [
     {
       "id": 1,
@@ -8,6 +8,12 @@
       "prompt": "How much did I spend on dining last month?",
       "expected_output": "Reports the total dining or restaurant category activity for last month, with enough context to identify the budget, category, month, and dollar amount used.",
       "category": "read",
+      "expected_code_refs": [
+        "spending_by_category",
+        "get_transactions",
+        "get_categories",
+        "get_category_for_month"
+      ],
       "expectations": []
     },
     {
@@ -16,6 +22,10 @@
       "prompt": "Show me the uncategorized transactions that still need cleanup.",
       "expected_output": "Lists uncategorized transactions needing attention, including dates, payees, amounts, ids, and whether each transaction is approved.",
       "category": "read",
+      "expected_code_refs": [
+        "get_transactions_needing_attention",
+        "get_transactions"
+      ],
       "expectations": []
     },
     {
@@ -24,6 +34,11 @@
       "prompt": "Which categories are over budget this month?",
       "expected_output": "Identifies categories with negative current-month balances or overspending, grouped or summarized clearly with category names and dollar amounts.",
       "category": "read",
+      "expected_code_refs": [
+        "get_categories",
+        "get_category_for_month",
+        "get_month"
+      ],
       "expectations": []
     },
     {
@@ -32,6 +47,10 @@
       "prompt": "What's my current cash balance across accounts?",
       "expected_output": "Summarizes current cash or on-budget account balances and gives a total in dollars, excluding closed or deleted accounts when account status is available.",
       "category": "read",
+      "expected_code_refs": [
+        "get_accounts",
+        "get_account_balance"
+      ],
       "expectations": []
     },
     {
@@ -40,6 +59,9 @@
       "prompt": "What are my largest transactions from the last 30 days?",
       "expected_output": "Returns the largest recent transactions with date, payee, category when available, amount, and transaction id so the user can inspect unusual spending.",
       "category": "read",
+      "expected_code_refs": [
+        "get_transactions"
+      ],
       "expectations": []
     },
     {

--- a/evals/run_prompt.py
+++ b/evals/run_prompt.py
@@ -40,17 +40,51 @@ except Exception:  # dotenv is optional for this script
 import _llm_eval_harness as harness  # noqa: E402
 
 
+def _is_auth_error(exc: BaseException) -> bool:
+    """True if exc is (or a group containing) an Anthropic auth error.
+
+    The error surfaces wrapped in anyio ExceptionGroups from the MCP task group,
+    so unwrap groups recursively.
+    """
+    import anthropic
+
+    if isinstance(exc, anthropic.AuthenticationError):
+        return True
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_is_auth_error(sub) for sub in exc.exceptions)
+    return False
+
+
+_AUTH_HELP = (
+    "Anthropic auth failed (401): the key in use is not a valid Console API key.\n"
+    "If your shell's ANTHROPIC_API_KEY is a Claude Code OAuth token (sk-ant-oat...),\n"
+    "it won't work against the Messages API. Set a real Console key for the eval:\n"
+    "    export EVAL_ANTHROPIC_API_KEY=sk-ant-api...\n"
+    "(EVAL_ANTHROPIC_API_KEY takes precedence and leaves your Claude Code setup alone.)"
+)
+
+
 async def _run(prompt: str, model: str) -> int:
-    missing = [k for k in ("ANTHROPIC_API_KEY", "YNAB_API_KEY") if not os.getenv(k)]
-    if missing:
+    problems = []
+    if not harness.eval_api_key():
+        problems.append("ANTHROPIC_API_KEY (or EVAL_ANTHROPIC_API_KEY)")
+    if not os.getenv("YNAB_API_KEY"):
+        problems.append("YNAB_API_KEY")
+    if problems:
         print(
-            f"Missing required env var(s): {', '.join(missing)}. "
+            f"Missing required credential(s): {', '.join(problems)}. "
             "Set them in your shell or a .env file at the repo root.",
             file=sys.stderr,
         )
         return 2
 
-    run = await harness.drive_prompt(prompt, model=model)
+    try:
+        run = await harness.drive_prompt(prompt, model=model)
+    except BaseException as exc:  # noqa: BLE001 - re-raised unless it's an auth error
+        if _is_auth_error(exc):
+            print(_AUTH_HELP, file=sys.stderr)
+            return 2
+        raise
 
     print(f"=== model: {model} | tool calls: {len(run.tool_calls)} ===")
     for i, call in enumerate(run.tool_calls, start=1):

--- a/evals/run_prompt.py
+++ b/evals/run_prompt.py
@@ -66,10 +66,12 @@ _AUTH_HELP = (
 
 async def _run(prompt: str, model: str) -> int:
     problems = []
-    if not harness.eval_api_key():
-        problems.append("ANTHROPIC_API_KEY (or EVAL_ANTHROPIC_API_KEY)")
     if not os.getenv("YNAB_API_KEY"):
         problems.append("YNAB_API_KEY")
+    # agent-sdk authenticates via the Claude subscription (claude CLI login),
+    # so it needs no Anthropic API key; messages-api does.
+    if harness.current_driver() == "messages-api" and not harness.eval_api_key():
+        problems.append("ANTHROPIC_API_KEY (or EVAL_ANTHROPIC_API_KEY)")
     if problems:
         print(
             f"Missing required credential(s): {', '.join(problems)}. "

--- a/evals/run_prompt.py
+++ b/evals/run_prompt.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""Run one ad-hoc prompt against the development mcp-ynab server.
+
+Drives Claude over the real MCP stdio transport against the *dev* server in the
+current venv (Code Mode, read-only), then prints the Code Mode tool calls
+(including the Python sent to ``execute``) and the final answer. Useful for
+poking at the server during development without writing a permanent eval.
+
+Read-only by construction: the server's ``code_mode_mutations_enabled`` defaults
+to False, so ``ynab.write.*`` is blocked and no change can reach YNAB.
+
+Usage (from the repo root, with ANTHROPIC_API_KEY + YNAB_API_KEY in env or .env)::
+
+    uv run python evals/run_prompt.py "How much did I spend on dining last month?"
+    uv run python evals/run_prompt.py --model claude-opus-4-8 "Which categories are over budget?"
+
+To point at a different build instead of the dev tree, set EVAL_MCP_COMMAND /
+EVAL_MCP_ARGS (e.g. EVAL_MCP_COMMAND=mcp-ynab EVAL_MCP_ARGS='[]' for the
+installed tool).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO / "tests" / "integration"))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(_REPO / ".env")
+except Exception:  # dotenv is optional for this script
+    pass
+
+import _llm_eval_harness as harness  # noqa: E402
+
+
+async def _run(prompt: str, model: str) -> int:
+    missing = [k for k in ("ANTHROPIC_API_KEY", "YNAB_API_KEY") if not os.getenv(k)]
+    if missing:
+        print(
+            f"Missing required env var(s): {', '.join(missing)}. "
+            "Set them in your shell or a .env file at the repo root.",
+            file=sys.stderr,
+        )
+        return 2
+
+    run = await harness.drive_prompt(prompt, model=model)
+
+    print(f"=== model: {model} | tool calls: {len(run.tool_calls)} ===")
+    for i, call in enumerate(run.tool_calls, start=1):
+        code = call.arguments.get("code")
+        print(f"\n[{i}] {call.name}")
+        if code:
+            print("    " + str(code).replace("\n", "\n    "))
+        else:
+            print(f"    args: {call.arguments}")
+    if run.stopped_early:
+        print("\n(!) stopped early — hit the max-iteration cap before a final answer")
+    print("\n=== final answer ===")
+    print(run.final_text or "(no final answer produced)")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run one prompt against the dev mcp-ynab server (read-only Code Mode)."
+    )
+    parser.add_argument("prompt", help="The natural-language prompt to send to Claude.")
+    parser.add_argument(
+        "--model",
+        default=os.getenv("EVAL_MODEL", harness.DEFAULT_EVAL_MODEL),
+        help="Anthropic model id (default: %(default)s).",
+    )
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(_run(args.prompt, args.model)))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
   "mcp[cli]>=1.20.0,<2.0.0",
   "pydantic>=2.10.0,<3",
-  "ynab>=1.0.1,<2.0.0",
+  "ynab>=4.1.0,<5.0.0",
   "python-dotenv>=1.2.2",
   "keyring>=25.7.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ dev = [
   "ruff>=0.9.4",
   "mypy>=1.15.0",
   "interrogate>=1.7.0",
+  # Drives the LLM-eval integration tests (tests/integration/test_llm_evals.py).
+  "anthropic>=0.40.0",
 ]
 
 [tool.interrogate]
@@ -80,6 +82,7 @@ pythonpath = ["src"]
 testpaths = ["tests"]
 markers = [
   "integration: marks tests as integration tests that require YNAB API access",
+  "eval: LLM-driven evals — require ANTHROPIC_API_KEY + YNAB_API_KEY and cost API tokens (also marked integration)",
   "asyncio: mark tests as async tests",
 ]
 addopts = "-v -ra --strict-markers -m 'not integration'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
   "interrogate>=1.7.0",
   # Drives the LLM-eval integration tests (tests/integration/test_llm_evals.py).
   "anthropic>=0.40.0",
+  "claude-agent-sdk>=0.2.104",
 ]
 
 [tool.interrogate]

--- a/src/mcp_ynab/formatters.py
+++ b/src/mcp_ynab/formatters.py
@@ -148,7 +148,7 @@ def _format_accounts_output(accounts: List[Dict[str, Any]]) -> Dict[str, Any]:
 def _process_category_data(category: Category | Dict[str, Any]) -> tuple[str, str, float, float]:
     """Process category data and return tuple of (id, name, budgeted, activity)."""
     if isinstance(category, Category):
-        return category.id, category.name, category.budgeted, category.activity
+        return str(category.id), category.name, category.budgeted, category.activity
     cat_dict = cast(Dict[str, Any], category)
     return cat_dict["id"], cat_dict["name"], cat_dict["budgeted"], cat_dict["activity"]
 

--- a/src/mcp_ynab/formatters.py
+++ b/src/mcp_ynab/formatters.py
@@ -47,6 +47,9 @@ def _build_markdown_table(
     if not rows:
         return _get_empty_table(headers)
 
+    # Cells are display data — coerce to str so non-str values (e.g. uuid.UUID
+    # ids from ynab >=2.x response models) don't break len()/format below.
+    rows = [[str(cell) for cell in row] for row in rows]
     alignments = alignments if alignments is not None else ["left"] * len(headers)
     col_count = len(headers)
     widths = _get_column_widths(headers, rows, col_count)

--- a/src/mcp_ynab/resources.py
+++ b/src/mcp_ynab/resources.py
@@ -230,7 +230,9 @@ async def list_payees_resource(budget_id: str) -> list[types.TextContent]:
     active = [p for p in payees if not getattr(p, "deleted", False)]
     raw = [
         {
-            "id": getattr(p, "id", None),
+            # Payee.id is a uuid.UUID in ynab >=2.x; coerce to str so the cache
+            # stays JSON-serializable (the cache writer uses plain json.dump).
+            "id": str(p.id) if getattr(p, "id", None) is not None else None,
             "name": getattr(p, "name", None),
             "transfer_account_id": getattr(p, "transfer_account_id", None),
         }

--- a/src/mcp_ynab/resources.py
+++ b/src/mcp_ynab/resources.py
@@ -257,7 +257,7 @@ async def _fetch_month_text(budget_id: str, month: str) -> list[types.TextConten
     """Fetch a month snapshot and return it as a single TextContent block."""
     async with await _s.get_ynab_client() as client:
         months_api = _s.MonthsApi(client)
-        response = months_api.get_budget_month(budget_id, _resolve_month(month))
+        response = months_api.get_plan_month(budget_id, _resolve_month(month))
         return [types.TextContent(type="text", text=_render_month_markdown(response.data.month))]
 
 

--- a/src/mcp_ynab/resources.py
+++ b/src/mcp_ynab/resources.py
@@ -83,9 +83,9 @@ def _currency_iso(currency_format: object) -> str:
 async def list_budgets_resource() -> list[types.TextContent]:
     """List all (non-closed/non-deleted) budgets as a markdown table."""
     async with await _s.get_ynab_client() as client:
-        budgets_api = _s.BudgetsApi(client)
-        response = budgets_api.get_budgets()
-        budgets = response.data.budgets or []
+        plans_api = _s.PlansApi(client)
+        response = plans_api.get_plans()
+        budgets = response.data.plans or []
 
         active = [
             b

--- a/src/mcp_ynab/server.py
+++ b/src/mcp_ynab/server.py
@@ -2,7 +2,7 @@
 
 The `mcp` FastMCP instance lives here, along with the shared tool-annotation
 constants and the singleton `ynab_resources` store. Module-level imports of
-the YNAB SDK API classes (`BudgetsApi`, `AccountsApi`, `CategoriesApi`,
+the YNAB SDK API classes (`PlansApi`, `AccountsApi`, `CategoriesApi`,
 `TransactionsApi`, `ExistingTransaction`, `PutTransactionWrapper`) are kept
 at this scope so tests can patch them via
 `monkeypatch.setattr(server, "<Name>", ...)`; tool modules access these names
@@ -29,7 +29,7 @@ from ynab.api_client import ApiClient
 # `monkeypatch.setattr(server, "<Name>", ...)`. Tool modules access them as
 # `server.<Name>` so those patches propagate via late attribute lookup.
 from ynab.api.accounts_api import AccountsApi  # noqa: F401
-from ynab.api.budgets_api import BudgetsApi  # noqa: F401
+from ynab.api.plans_api import PlansApi  # noqa: F401
 from ynab.api.categories_api import CategoriesApi  # noqa: F401
 from ynab.api.months_api import MonthsApi  # noqa: F401
 from ynab.api.payees_api import PayeesApi  # noqa: F401
@@ -107,12 +107,12 @@ async def _resolve_budget_id(client: ApiClient, ctx: Optional[Context]) -> str:
     if budget_id:
         return budget_id
 
-    budgets_api = BudgetsApi(client)
-    budgets = budgets_api.get_budgets().data.budgets
+    plans_api = PlansApi(client)
+    budgets = plans_api.get_plans().data.plans
     if not budgets:
         raise ValueError("No YNAB budgets available on this account.")
     if len(budgets) == 1:
-        return budgets[0].id
+        return str(budgets[0].id)
 
     if ctx is None:
         raise ValueError(
@@ -133,9 +133,10 @@ async def _resolve_budget_id(client: ApiClient, ctx: Optional[Context]) -> str:
                 f"Selected budget index {choice.index} out of range 1..{len(budgets)}."
             )
         chosen = budgets[choice.index - 1]
+        chosen_id = str(chosen.id)
         if choice.set_as_preferred:
-            ynab_resources.set_preferred_budget_id(chosen.id)
-        return chosen.id
+            ynab_resources.set_preferred_budget_id(chosen_id)
+        return chosen_id
     if result.action == "decline":
         raise ValueError("Budget selection declined; cannot proceed.")
     raise ValueError("Budget selection cancelled; cannot proceed.")

--- a/src/mcp_ynab/state.py
+++ b/src/mcp_ynab/state.py
@@ -61,10 +61,15 @@ def _save_json_file(filename: str | Path, data: Dict[str, Any]) -> None:
 
 
 def _atomic_write_json(filename: Path, data: Dict[str, Any]) -> None:
-    """Write JSON to ``filename`` atomically via a sibling tempfile + os.replace."""
+    """Write JSON to ``filename`` atomically via a sibling tempfile + os.replace.
+
+    ``default=str`` coerces non-JSON-native values (notably ``uuid.UUID`` ids
+    from ynab >=2.x ``Category.to_dict()``, which ``json.dump`` would otherwise
+    reject) to their string form — cache records are str-compared on read.
+    """
     tmp = filename.with_suffix(filename.suffix + ".tmp")
     with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+        json.dump(data, f, indent=2, default=str)
     os.replace(tmp, filename)
 
 

--- a/src/mcp_ynab/tools/budgeting.py
+++ b/src/mcp_ynab/tools/budgeting.py
@@ -1,8 +1,8 @@
 """Budget, account, and category MCP tools.
 
-Tool bodies look up YNAB SDK API classes (`BudgetsApi`, `AccountsApi`,
+Tool bodies look up YNAB SDK API classes (`PlansApi`, `AccountsApi`,
 `CategoriesApi`) and `ynab_resources` via the `server` module so that
-`monkeypatch.setattr(server, "BudgetsApi", ...)` in tests propagates here
+`monkeypatch.setattr(server, "PlansApi", ...)` in tests propagates here
 through late attribute lookup. Pure formatting helpers are imported from
 `mcp_ynab.formatters` since tests do not patch them.
 """
@@ -16,7 +16,7 @@ from ynab.models.category_group_with_categories import CategoryGroupWithCategori
 from ynab.models.patch_category_wrapper import PatchCategoryWrapper
 from ynab.models.patch_payee_wrapper import PatchPayeeWrapper
 from ynab.models.patch_transactions_wrapper import PatchTransactionsWrapper
-from ynab.models.save_category import SaveCategory
+from ynab.models.existing_category import ExistingCategory
 from ynab.models.save_payee import SavePayee
 from ynab.models.save_transaction_with_id_or_import_id import SaveTransactionWithIdOrImportId
 
@@ -57,9 +57,9 @@ async def get_account_balance(account_id: str, ctx: Optional[Context] = None) ->
 async def get_budgets() -> str:
     """List all YNAB budgets in Markdown format."""
     async with await _s.get_ynab_client() as client:
-        budgets_api = _s.BudgetsApi(client)
-        budgets_response = budgets_api.get_budgets()
-        budgets_list = budgets_response.data.budgets
+        plans_api = _s.PlansApi(client)
+        budgets_response = plans_api.get_plans()
+        budgets_list = budgets_response.data.plans
 
         markdown = "# YNAB Budgets\n\n"
         if not budgets_list:
@@ -361,15 +361,21 @@ async def update_category(
     name: Optional[str] = None,
     note: Optional[str] = None,
     category_group_id: Optional[str] = None,
+    goal_target: Optional[float] = None,
+    goal_target_date: Optional[str] = None,
+    goal_needs_whole_amount: Optional[bool] = None,
 ) -> str:
-    """Rename a category, update its note, or move it to a different category group.
+    """Rename a category, edit its note/group, or set its recurring monthly goal.
 
-    At least one of `name`, `note`, or `category_group_id` must be provided.
-    Idempotent: applying the same values twice leaves the category unchanged.
+    At least one updatable field must be provided. Idempotent: applying the
+    same values twice leaves the category unchanged.
 
-    Note: YNAB API v1 does not support setting goals via API. Goal fields
-    (goal_type, goal_target, etc.) appear on the read model but the write
-    model (SaveCategory) only accepts name, note, and category_group_id.
+    The `goal_*` fields map onto YNAB's category PATCH endpoint, which now
+    accepts them (this was previously an API limitation). Setting `goal_target`
+    on a category that has no goal creates a monthly NEED goal by default; it
+    only applies to goal types with a target amount (NEED/TB/TBD/MF). This is
+    distinct from `assign_money`, which sets the per-month *assigned* amount —
+    here we change the recurring *target*.
 
     Args:
         budget_id: The YNAB budget ID.
@@ -377,11 +383,37 @@ async def update_category(
         name: New display name for the category (optional).
         note: New note/memo for the category (optional).
         category_group_id: ID of the category group to move the category into (optional).
+        goal_target: Goal target in dollars (converted to milliunits). Creates a
+            monthly NEED goal when the category has no goal yet.
+        goal_target_date: Goal target date as an ISO date string (e.g. "2026-07-01").
+        goal_needs_whole_amount: NEED goals only — True selects "Set Aside" (the
+            whole amount each period), False selects "Refill" (up to the target).
     """
-    if name is None and note is None and category_group_id is None:
-        raise ValueError("At least one of name, note, or category_group_id must be provided.")
+    if (
+        name is None
+        and note is None
+        and category_group_id is None
+        and goal_target is None
+        and goal_target_date is None
+        and goal_needs_whole_amount is None
+    ):
+        raise ValueError(
+            "At least one of name, note, category_group_id, goal_target, "
+            "goal_target_date, or goal_needs_whole_amount must be provided."
+        )
+    goal_target_milliunits = int(round(goal_target * 1000)) if goal_target is not None else None
+    parsed_goal_date = date.fromisoformat(goal_target_date) if goal_target_date else None
+    # ExistingCategory serializes with exclude_none, so only the fields set here
+    # reach the wire; omitted fields are left untouched by YNAB's PATCH.
     wrapper = PatchCategoryWrapper(
-        category=SaveCategory(name=name, note=note, category_group_id=category_group_id)
+        category=ExistingCategory(
+            name=name,
+            note=note,
+            category_group_id=category_group_id,
+            goal_target=goal_target_milliunits,
+            goal_target_date=parsed_goal_date,
+            goal_needs_whole_amount=goal_needs_whole_amount,
+        )
     )
     async with await _s.get_ynab_client() as client:
         cats = _s.CategoriesApi(client)
@@ -394,6 +426,12 @@ async def update_category(
         parts.append(f"note set to `{cat.note}`")
     if category_group_id is not None:
         parts.append(f"moved to group `{category_group_id}`")
+    if goal_target is not None:
+        parts.append(f"goal target set to ${goal_target:,.2f}")
+    if parsed_goal_date is not None:
+        parts.append(f"goal target date set to `{parsed_goal_date.isoformat()}`")
+    if goal_needs_whole_amount is not None:
+        parts.append(f"goal mode set to {'Set Aside' if goal_needs_whole_amount else 'Refill'}")
     return f"Category `{category_id}` updated: {', '.join(parts)}."
 
 

--- a/src/mcp_ynab/tools/budgeting.py
+++ b/src/mcp_ynab/tools/budgeting.py
@@ -207,7 +207,7 @@ async def get_month(budget_id: str, month: str = "current") -> str:
     """
     async with await _s.get_ynab_client() as client:
         months_api = _s.MonthsApi(client)
-        response = months_api.get_budget_month(budget_id, _resolve_month(month))
+        response = months_api.get_plan_month(budget_id, _resolve_month(month))
         return _render_month_markdown(response.data.month)
 
 
@@ -402,7 +402,11 @@ async def update_category(
             "goal_target_date, or goal_needs_whole_amount must be provided."
         )
     goal_target_milliunits = int(round(goal_target * 1000)) if goal_target is not None else None
-    parsed_goal_date = date.fromisoformat(goal_target_date) if goal_target_date else None
+    # `is not None` (not truthiness) so an empty string raises a clear ValueError
+    # rather than silently slipping past the guard above as a no-op update.
+    parsed_goal_date = (
+        date.fromisoformat(goal_target_date) if goal_target_date is not None else None
+    )
     # ExistingCategory serializes with exclude_none, so only the fields set here
     # reach the wire; omitted fields are left untouched by YNAB's PATCH.
     wrapper = PatchCategoryWrapper(

--- a/src/mcp_ynab/tools/transactions.py
+++ b/src/mcp_ynab/tools/transactions.py
@@ -2,7 +2,7 @@
 
 `create_transaction`, `get_transactions`, `get_transactions_needing_attention`,
 `categorize_transaction`, `bulk_categorize`, and `update_transaction`. SDK
-API classes (`TransactionsApi`, `BudgetsApi`, `AccountsApi`,
+API classes (`TransactionsApi`, `PlansApi`, `AccountsApi`,
 `CategoriesApi`), `ExistingTransaction`, `PutTransactionWrapper`, and
 `ynab_resources` are looked up via the `server` module so test
 monkeypatches propagate.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,13 +46,13 @@ def mock_ynab_apis(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
 
     Returns a SimpleNamespace with `budgets`, `accounts`, `categories`, and
     `transactions` MagicMock instances. Tests configure return values on these
-    mocks (e.g. `mock_ynab_apis.budgets.get_budgets.return_value = ...`) and
+    mocks (e.g. `mock_ynab_apis.budgets.get_plans.return_value = ...`) and
     then call the tool function under test directly.
     """
     from mcp_ynab import server
 
     apis = SimpleNamespace(
-        budgets=MagicMock(name="BudgetsApi"),
+        budgets=MagicMock(name="PlansApi"),
         accounts=MagicMock(name="AccountsApi"),
         categories=MagicMock(name="CategoriesApi"),
         transactions=MagicMock(name="TransactionsApi"),
@@ -73,7 +73,7 @@ def mock_ynab_apis(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
         return _DummyClientCtx()
 
     monkeypatch.setattr(server, "get_ynab_client", _fake_get_ynab_client)
-    monkeypatch.setattr(server, "BudgetsApi", lambda client: apis.budgets)
+    monkeypatch.setattr(server, "PlansApi", lambda client: apis.budgets)
     monkeypatch.setattr(server, "AccountsApi", lambda client: apis.accounts)
     monkeypatch.setattr(server, "CategoriesApi", lambda client: apis.categories)
     monkeypatch.setattr(server, "TransactionsApi", lambda client: apis.transactions)

--- a/tests/integration/_llm_eval_harness.py
+++ b/tests/integration/_llm_eval_harness.py
@@ -29,6 +29,21 @@ from typing import Any
 DEFAULT_EVAL_MODEL = "claude-sonnet-4-6"
 DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
 
+# Two ways to drive the eval, selected by EVAL_DRIVER:
+#   "messages-api" (default) — the anthropic Messages API; bills API tokens.
+#   "agent-sdk"             — the Claude Agent SDK (the Claude Code engine),
+#                             authenticated by your Claude *subscription* via the
+#                             logged-in `claude` CLI (or CLAUDE_CODE_OAUTH_TOKEN).
+#                             Draws against your subscription's usage, not an API
+#                             balance.
+DEFAULT_DRIVER = "messages-api"
+
+
+def current_driver() -> str:
+    """The selected eval driver (``messages-api`` or ``agent-sdk``)."""
+    return os.getenv("EVAL_DRIVER", DEFAULT_DRIVER)
+
+
 # Orient the model to the Code Mode surface so the eval measures whether the
 # tools work — not whether the model can rediscover the Code Mode convention
 # cold. Mirrors what the ynab://code-mode/examples + stubs resources convey.
@@ -173,7 +188,21 @@ def _server_params() -> Any:
 
 
 async def drive_prompt(prompt: str, *, model: str, max_iterations: int = 8) -> EvalRun:
-    """Drive ``prompt`` to a final answer using the live mcp-ynab tools."""
+    """Drive ``prompt`` to a final answer using the live mcp-ynab tools.
+
+    Dispatches to the configured backend (EVAL_DRIVER). Both return an EvalRun
+    with the same shape so the structural checks and judge work identically.
+    """
+    driver = current_driver()
+    if driver == "agent-sdk":
+        return await _drive_via_agent_sdk(prompt, model=model)
+    if driver == "messages-api":
+        return await _drive_via_messages_api(prompt, model=model, max_iterations=max_iterations)
+    raise ValueError(f"Unknown EVAL_DRIVER {driver!r} (use 'messages-api' or 'agent-sdk').")
+
+
+async def _drive_via_messages_api(prompt: str, *, model: str, max_iterations: int = 8) -> EvalRun:
+    """Drive ``prompt`` with the anthropic Messages API (bills API tokens)."""
     from mcp import ClientSession
     from mcp.client.stdio import stdio_client
 
@@ -225,29 +254,170 @@ async def drive_prompt(prompt: str, *, model: str, max_iterations: int = 8) -> E
     return run
 
 
-async def judge_answer(
-    prompt: str, expected_output: str, final_text: str, *, model: str
-) -> tuple[bool, str]:
-    """Use an LLM judge to score ``final_text`` against ``expected_output``."""
-    client = _anthropic_client()
-    system = (
-        "You are a strict but fair evaluator of an AI budgeting assistant. Given the user's "
-        "task, a description of the expected output, and the assistant's final answer, decide "
-        "whether the answer satisfies the expectation. Judge substance, not exact wording. "
-        "Always respond by calling record_verdict."
+def _normalize_tool_name(name: str) -> str:
+    """Strip the ``mcp__<server>__`` prefix the Agent SDK adds to MCP tools.
+
+    So ``mcp__ynab__execute`` becomes ``execute`` and the structural checks
+    (read-tool engagement, write-tool gate) match across both drivers.
+    """
+    return name.split("__")[-1] if name.startswith("mcp__") else name
+
+
+def _subscription_env() -> dict[str, str]:
+    """Env overrides that force the Agent SDK onto Claude subscription auth.
+
+    Blanks out any API-key / Bedrock vars that would win over the logged-in
+    `claude` CLI credentials; honors an explicit EVAL_CLAUDE_CODE_OAUTH_TOKEN
+    (from `claude setup-token`) if set, else falls back to the existing login.
+    """
+    env = {
+        "ANTHROPIC_API_KEY": "",
+        "ANTHROPIC_AUTH_TOKEN": "",
+        "CLAUDE_CODE_USE_BEDROCK": "false",
+    }
+    token = os.getenv("EVAL_CLAUDE_CODE_OAUTH_TOKEN") or os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+    if token:
+        env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+    return env
+
+
+def agent_sdk_options(model: str) -> Any:
+    """Build ClaudeAgentOptions for the subscription-auth Agent SDK driver."""
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    command = os.getenv("EVAL_MCP_COMMAND", sys.executable)
+    args = json.loads(os.getenv("EVAL_MCP_ARGS", '["-m", "mcp_ynab"]'))
+
+    return ClaudeAgentOptions(
+        model=model,
+        mcp_servers={
+            "ynab": {
+                "type": "stdio",
+                "command": command,
+                "args": args,
+                "env": dict(os.environ),
+            }
+        },
+        # Only the Code Mode tools may run; dontAsk denies anything unlisted
+        # rather than prompting (this is a non-interactive eval).
+        allowed_tools=["mcp__ynab__execute", "mcp__ynab__search"],
+        disallowed_tools=["Bash", "Read", "Write", "Edit", "WebFetch", "WebSearch"],
+        permission_mode="dontAsk",
+        # Isolate from the user's global Claude Code config (other MCP servers,
+        # hooks, skills, CLAUDE.md) so the eval is reproducible.
+        setting_sources=[],
+        strict_mcp_config=True,
+        max_turns=int(os.getenv("EVAL_MAX_TURNS", "12")),
+        env=_subscription_env(),
     )
-    user = (
+
+
+async def _drive_via_agent_sdk(prompt: str, *, model: str) -> EvalRun:
+    """Drive ``prompt`` with the Claude Agent SDK (subscription auth)."""
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeSDKClient,
+        TextBlock,
+        ToolUseBlock,
+    )
+
+    run = EvalRun()
+    async with ClaudeSDKClient(options=agent_sdk_options(model)) as client:
+        await client.query(prompt)
+        async for message in client.receive_response():
+            if not isinstance(message, AssistantMessage):
+                continue
+            for block in message.content:
+                if isinstance(block, ToolUseBlock):
+                    run.tool_calls.append(
+                        ToolCall(_normalize_tool_name(block.name), dict(block.input or {}))
+                    )
+                elif isinstance(block, TextBlock) and block.text and block.text.strip():
+                    run.final_text = block.text  # last non-empty assistant text wins
+    return run
+
+
+_JUDGE_SYSTEM = (
+    "You are a strict but fair evaluator of an AI budgeting assistant. Given the user's "
+    "task, a description of the expected output, and the assistant's final answer, decide "
+    "whether the answer satisfies the expectation. Judge substance, not exact wording."
+)
+
+
+def _judge_user_prompt(prompt: str, expected_output: str, final_text: str) -> str:
+    return (
         f"User task:\n{prompt}\n\n"
         f"Expected output:\n{expected_output}\n\n"
         f"Assistant final answer:\n{final_text or '(empty)'}\n\n"
+    )
+
+
+async def judge_answer(
+    prompt: str, expected_output: str, final_text: str, *, model: str
+) -> tuple[bool, str]:
+    """Use an LLM judge to score ``final_text`` against ``expected_output``.
+
+    Routes through the same driver as the run so an agent-sdk eval judges on the
+    subscription too (rather than falling back to the billed Messages API).
+    """
+    if current_driver() == "agent-sdk":
+        return await _judge_via_agent_sdk(prompt, expected_output, final_text, model=model)
+
+    client = _anthropic_client()
+    user = _judge_user_prompt(prompt, expected_output, final_text) + (
         "Call record_verdict with whether the answer satisfies the expected output."
     )
     response = await client.messages.create(
         model=model,
         max_tokens=512,
-        system=system,
+        system=_JUDGE_SYSTEM + " Always respond by calling record_verdict.",
         tools=[_verdict_tool_schema()],
         tool_choice={"type": "tool", "name": "record_verdict"},
         messages=[{"role": "user", "content": user}],
     )
     return parse_verdict(response.content)
+
+
+async def _judge_via_agent_sdk(
+    prompt: str, expected_output: str, final_text: str, *, model: str
+) -> tuple[bool, str]:
+    """LLM judge over the Agent SDK (subscription auth), no tools.
+
+    Asks for a ``VERDICT: pass|fail`` first line plus a one-line reason, and
+    parses that — structured tool-calling isn't needed for a yes/no verdict.
+    """
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ClaudeSDKClient,
+        TextBlock,
+    )
+
+    options = ClaudeAgentOptions(
+        model=model,
+        allowed_tools=[],
+        disallowed_tools=["Bash", "Read", "Write", "Edit", "WebFetch", "WebSearch"],
+        permission_mode="dontAsk",
+        setting_sources=[],
+        strict_mcp_config=True,
+        max_turns=1,
+        env=_subscription_env(),
+    )
+    instruction = (
+        _JUDGE_SYSTEM
+        + "\n\n"
+        + _judge_user_prompt(prompt, expected_output, final_text)
+        + "Reply with a first line exactly 'VERDICT: pass' or 'VERDICT: fail', then a "
+        "one-sentence reason on the next line. Do not use any tools."
+    )
+    text = ""
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(instruction)
+        async for message in client.receive_response():
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock) and block.text:
+                        text += block.text
+    lowered = text.lower()
+    passed = "verdict: pass" in lowered or lowered.lstrip().startswith("pass")
+    return passed, text.strip()[:500] or "judge returned no text"

--- a/tests/integration/_llm_eval_harness.py
+++ b/tests/integration/_llm_eval_harness.py
@@ -327,13 +327,19 @@ async def _drive_via_agent_sdk(prompt: str, *, model: str) -> EvalRun:
         async for message in client.receive_response():
             if not isinstance(message, AssistantMessage):
                 continue
+            message_text: list[str] = []
             for block in message.content:
                 if isinstance(block, ToolUseBlock):
                     run.tool_calls.append(
                         ToolCall(_normalize_tool_name(block.name), dict(block.input or {}))
                     )
-                elif isinstance(block, TextBlock) and block.text and block.text.strip():
-                    run.final_text = block.text  # last non-empty assistant text wins
+                elif isinstance(block, TextBlock) and block.text:
+                    message_text.append(block.text)
+            joined = "".join(message_text).strip()
+            if joined:
+                # Full text of the latest assistant message wins (don't truncate
+                # a multi-block answer to its last fragment).
+                run.final_text = joined
     return run
 
 

--- a/tests/integration/_llm_eval_harness.py
+++ b/tests/integration/_llm_eval_harness.py
@@ -28,6 +28,21 @@ from typing import Any
 DEFAULT_EVAL_MODEL = "claude-sonnet-4-6"
 DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
 
+# Orient the model to the Code Mode surface so the eval measures whether the
+# tools work — not whether the model can rediscover the Code Mode convention
+# cold. Mirrors what the ynab://code-mode/examples + stubs resources convey.
+CODE_MODE_SYSTEM = (
+    "You operate a YNAB budget through a Code Mode interface exposed as two tools:\n"
+    "- `search`: find available YNAB operations when you're unsure what exists.\n"
+    "- `execute`: run a Python snippet. The snippet is the body of an async function "
+    "with a `ynab` object in scope. Call read operations as "
+    "`await ynab.read.<operation>(...)` and `return` the value you want back.\n\n"
+    "Resolve ids (budget, category, account) by reading them rather than guessing. "
+    "The environment is read-only: `ynab.write.*` is unavailable, so for any change "
+    "request, gather the relevant data and describe what you would do — do not attempt "
+    "to apply it. When done, give the user a clear final answer in plain language."
+)
+
 # YNAB-mutating tools. Dry-run/read evals must never call these — the structural
 # gate in test_llm_evals.py enforces it so a "dry run" prompt can't quietly
 # change the live budget. Local-state tools (cache_*, set_preferred_budget_id,
@@ -157,6 +172,7 @@ async def drive_prompt(prompt: str, *, model: str, max_iterations: int = 8) -> E
                 response = await client.messages.create(
                     model=model,
                     max_tokens=2048,
+                    system=CODE_MODE_SYSTEM,
                     tools=anthropic_tools,
                     messages=messages,
                 )

--- a/tests/integration/_llm_eval_harness.py
+++ b/tests/integration/_llm_eval_harness.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -142,13 +143,16 @@ def parse_verdict(content_blocks: list[Any]) -> tuple[bool, str]:
 def _server_params() -> Any:
     """Build StdioServerParameters for launching the mcp-ynab subprocess.
 
-    Overridable via EVAL_MCP_COMMAND / EVAL_MCP_ARGS (JSON list) for unusual
-    environments; defaults to ``uv run mcp-ynab``.
+    Defaults to ``<this interpreter> -m mcp_ynab`` so the eval always exercises
+    the *development* server in the current venv (the editable install on the
+    checked-out branch) rather than a globally installed mcp-ynab. Override via
+    EVAL_MCP_COMMAND / EVAL_MCP_ARGS (JSON list) to point at a different build —
+    e.g. EVAL_MCP_COMMAND=mcp-ynab EVAL_MCP_ARGS='[]' for the installed tool.
     """
     from mcp import StdioServerParameters
 
-    command = os.getenv("EVAL_MCP_COMMAND", "uv")
-    args = json.loads(os.getenv("EVAL_MCP_ARGS", '["run", "mcp-ynab"]'))
+    command = os.getenv("EVAL_MCP_COMMAND", sys.executable)
+    args = json.loads(os.getenv("EVAL_MCP_ARGS", '["-m", "mcp_ynab"]'))
     return StdioServerParameters(command=command, args=args, env=dict(os.environ))
 
 

--- a/tests/integration/_llm_eval_harness.py
+++ b/tests/integration/_llm_eval_harness.py
@@ -1,0 +1,220 @@
+"""Harness for LLM-driven YNAB evals over the real MCP stdio transport.
+
+The flow per eval:
+
+1. Launch the ``mcp-ynab`` server as a subprocess and connect with the MCP
+   stdio client (so the *real* server, tool schemas, and transport are
+   exercised — not in-process shims).
+2. Convert the server's advertised tools into Anthropic tool schemas and let
+   Claude drive a tool-use loop against the live session.
+3. Capture the tool calls Claude made and its final natural-language answer.
+4. Score the answer against the eval's ``expected_output`` with an LLM judge.
+
+``anthropic`` and ``mcp`` clients are imported lazily inside the async
+functions so this module (and its pure helpers) import without API keys — the
+unit tests in ``tests/test_llm_eval_harness.py`` exercise the pure helpers with
+fakes, while the real run lives behind the ``eval`` marker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+# Default models are overridable via env so the suite can pin cheaper/newer
+# models without code changes.
+DEFAULT_EVAL_MODEL = "claude-sonnet-4-6"
+DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
+
+# YNAB-mutating tools. Dry-run/read evals must never call these — the structural
+# gate in test_llm_evals.py enforces it so a "dry run" prompt can't quietly
+# change the live budget. Local-state tools (cache_*, set_preferred_budget_id,
+# set_preference) are intentionally excluded; they don't touch YNAB.
+YNAB_WRITE_TOOLS = frozenset(
+    {
+        "create_transaction",
+        "update_transaction",
+        "delete_transaction",
+        "bulk_categorize",
+        "categorize_transaction",
+        "approve_transactions",
+        "import_transactions",
+        "create_scheduled_transaction",
+        "update_category",
+        "assign_money",
+        "move_money",
+        "merge_payees",
+        "rename_payee",
+        "set_api_key",
+        "clear_api_key",
+    }
+)
+
+
+@dataclass
+class ToolCall:
+    """One tool invocation Claude made during an eval run."""
+
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass
+class EvalRun:
+    """Outcome of driving one eval prompt to completion."""
+
+    final_text: str = ""
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    stopped_early: bool = False
+
+    @property
+    def tool_names(self) -> list[str]:
+        """Names of every tool Claude called, in order."""
+        return [tc.name for tc in self.tool_calls]
+
+
+def mcp_tools_to_anthropic(mcp_tools: list[Any]) -> list[dict[str, Any]]:
+    """Convert MCP ``Tool`` objects to Anthropic tool-schema dicts."""
+    schemas: list[dict[str, Any]] = []
+    for tool in mcp_tools:
+        schemas.append(
+            {
+                "name": tool.name,
+                "description": (getattr(tool, "description", None) or "")[:1024],
+                "input_schema": getattr(tool, "inputSchema", None)
+                or {"type": "object", "properties": {}},
+            }
+        )
+    return schemas
+
+
+def tool_result_to_text(result: Any) -> str:
+    """Flatten an MCP ``call_tool`` result's content blocks into text."""
+    parts: list[str] = []
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _verdict_tool_schema() -> dict[str, Any]:
+    return {
+        "name": "record_verdict",
+        "description": "Record whether the assistant's answer satisfies the expected output.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "passed": {"type": "boolean"},
+                "reason": {"type": "string"},
+            },
+            "required": ["passed", "reason"],
+        },
+    }
+
+
+def parse_verdict(content_blocks: list[Any]) -> tuple[bool, str]:
+    """Extract (passed, reason) from a judge response's content blocks."""
+    for block in content_blocks:
+        if getattr(block, "type", None) == "tool_use" and block.name == "record_verdict":
+            data = block.input or {}
+            return bool(data.get("passed")), str(data.get("reason", ""))
+    return False, "judge did not return a verdict"
+
+
+def _server_params() -> Any:
+    """Build StdioServerParameters for launching the mcp-ynab subprocess.
+
+    Overridable via EVAL_MCP_COMMAND / EVAL_MCP_ARGS (JSON list) for unusual
+    environments; defaults to ``uv run mcp-ynab``.
+    """
+    from mcp import StdioServerParameters
+
+    command = os.getenv("EVAL_MCP_COMMAND", "uv")
+    args = json.loads(os.getenv("EVAL_MCP_ARGS", '["run", "mcp-ynab"]'))
+    return StdioServerParameters(command=command, args=args, env=dict(os.environ))
+
+
+async def drive_prompt(prompt: str, *, model: str, max_iterations: int = 8) -> EvalRun:
+    """Drive ``prompt`` to a final answer using the live mcp-ynab tools."""
+    import anthropic
+    from mcp import ClientSession
+    from mcp.client.stdio import stdio_client
+
+    client = anthropic.AsyncAnthropic()
+    run = EvalRun()
+
+    async with stdio_client(_server_params()) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = (await session.list_tools()).tools
+            anthropic_tools = mcp_tools_to_anthropic(tools)
+
+            messages: list[dict[str, Any]] = [{"role": "user", "content": prompt}]
+            for _ in range(max_iterations):
+                response = await client.messages.create(
+                    model=model,
+                    max_tokens=2048,
+                    tools=anthropic_tools,
+                    messages=messages,
+                )
+                if response.stop_reason != "tool_use":
+                    run.final_text = "".join(b.text for b in response.content if b.type == "text")
+                    return run
+
+                messages.append(
+                    {"role": "assistant", "content": [b.model_dump() for b in response.content]}
+                )
+                tool_results: list[dict[str, Any]] = []
+                for block in response.content:
+                    if block.type != "tool_use":
+                        continue
+                    run.tool_calls.append(ToolCall(block.name, dict(block.input)))
+                    try:
+                        result = await session.call_tool(block.name, dict(block.input))
+                        content = tool_result_to_text(result) or "(no content)"
+                    except Exception as exc:  # surface tool errors back to the model
+                        content = f"ERROR calling {block.name}: {exc}"
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": content,
+                        }
+                    )
+                messages.append({"role": "user", "content": tool_results})
+
+    run.stopped_early = True
+    return run
+
+
+async def judge_answer(
+    prompt: str, expected_output: str, final_text: str, *, model: str
+) -> tuple[bool, str]:
+    """Use an LLM judge to score ``final_text`` against ``expected_output``."""
+    import anthropic
+
+    client = anthropic.AsyncAnthropic()
+    system = (
+        "You are a strict but fair evaluator of an AI budgeting assistant. Given the user's "
+        "task, a description of the expected output, and the assistant's final answer, decide "
+        "whether the answer satisfies the expectation. Judge substance, not exact wording. "
+        "Always respond by calling record_verdict."
+    )
+    user = (
+        f"User task:\n{prompt}\n\n"
+        f"Expected output:\n{expected_output}\n\n"
+        f"Assistant final answer:\n{final_text or '(empty)'}\n\n"
+        "Call record_verdict with whether the answer satisfies the expected output."
+    )
+    response = await client.messages.create(
+        model=model,
+        max_tokens=512,
+        system=system,
+        tools=[_verdict_tool_schema()],
+        tool_choice={"type": "tool", "name": "record_verdict"},
+        messages=[{"role": "user", "content": user}],
+    )
+    return parse_verdict(response.content)

--- a/tests/integration/_llm_eval_harness.py
+++ b/tests/integration/_llm_eval_harness.py
@@ -140,6 +140,22 @@ def parse_verdict(content_blocks: list[Any]) -> tuple[bool, str]:
     return False, "judge did not return a verdict"
 
 
+def eval_api_key() -> str | None:
+    """The Anthropic key to drive evals with.
+
+    Prefers EVAL_ANTHROPIC_API_KEY so the eval can use a real Console API key
+    without colliding with an ANTHROPIC_API_KEY that the shell may have set to a
+    Claude Code OAuth token (which the Messages API rejects with 401).
+    """
+    return os.getenv("EVAL_ANTHROPIC_API_KEY") or os.getenv("ANTHROPIC_API_KEY")
+
+
+def _anthropic_client() -> Any:
+    import anthropic
+
+    return anthropic.AsyncAnthropic(api_key=eval_api_key())
+
+
 def _server_params() -> Any:
     """Build StdioServerParameters for launching the mcp-ynab subprocess.
 
@@ -158,11 +174,10 @@ def _server_params() -> Any:
 
 async def drive_prompt(prompt: str, *, model: str, max_iterations: int = 8) -> EvalRun:
     """Drive ``prompt`` to a final answer using the live mcp-ynab tools."""
-    import anthropic
     from mcp import ClientSession
     from mcp.client.stdio import stdio_client
 
-    client = anthropic.AsyncAnthropic()
+    client = _anthropic_client()
     run = EvalRun()
 
     async with stdio_client(_server_params()) as (read, write):
@@ -214,9 +229,7 @@ async def judge_answer(
     prompt: str, expected_output: str, final_text: str, *, model: str
 ) -> tuple[bool, str]:
     """Use an LLM judge to score ``final_text`` against ``expected_output``."""
-    import anthropic
-
-    client = anthropic.AsyncAnthropic()
+    client = _anthropic_client()
     system = (
         "You are a strict but fair evaluator of an AI budgeting assistant. Given the user's "
         "task, a description of the expected output, and the assistant's final answer, decide "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,13 +28,13 @@ def _require_api_key() -> None:
 def integration_first_budget_id() -> str:
     """Discover the first budget id on the account; cache for the session."""
     _require_api_key()
-    from ynab.api.budgets_api import BudgetsApi
+    from ynab.api.plans_api import PlansApi
     from ynab.api_client import ApiClient
     from ynab.configuration import Configuration
 
     config = Configuration(access_token=os.environ["YNAB_API_KEY"])
     with ApiClient(config) as client:
-        budgets = BudgetsApi(client).get_budgets().data.budgets
+        budgets = PlansApi(client).get_plans().data.plans
         if not budgets:
             pytest.skip("YNAB account has no budgets")
         return budgets[0].id

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,7 +37,7 @@ def integration_first_budget_id() -> str:
         budgets = PlansApi(client).get_plans().data.plans
         if not budgets:
             pytest.skip("YNAB account has no budgets")
-        return budgets[0].id
+        return str(budgets[0].id)
 
 
 @pytest.fixture(scope="session")
@@ -52,7 +52,7 @@ def integration_first_account_id(integration_first_budget_id: str) -> str:
         accounts = AccountsApi(client).get_accounts(integration_first_budget_id).data.accounts
         for acct in accounts:
             if not acct.closed and not acct.deleted:
-                return acct.id
+                return str(acct.id)
         pytest.skip("First budget has no open accounts")
         raise RuntimeError("unreachable")  # for type checker
 

--- a/tests/integration/test_llm_evals.py
+++ b/tests/integration/test_llm_evals.py
@@ -23,6 +23,7 @@ from tests.integration._llm_eval_harness import (
     DEFAULT_EVAL_MODEL,
     DEFAULT_JUDGE_MODEL,
     YNAB_WRITE_TOOLS,
+    current_driver,
     drive_prompt,
     eval_api_key,
     judge_answer,
@@ -44,10 +45,13 @@ _EVAL_CASES = _load_eval_cases()
 
 def _require_eval_keys() -> None:
     missing = []
-    if not eval_api_key():
-        missing.append("ANTHROPIC_API_KEY (or EVAL_ANTHROPIC_API_KEY)")
     if not os.getenv("YNAB_API_KEY"):
         missing.append("YNAB_API_KEY")
+    # The messages-api driver needs an Anthropic API key; the agent-sdk driver
+    # authenticates via the Claude subscription (logged-in `claude` CLI or
+    # CLAUDE_CODE_OAUTH_TOKEN), which can't be cheaply pre-checked here.
+    if current_driver() == "messages-api" and not eval_api_key():
+        missing.append("ANTHROPIC_API_KEY (or EVAL_ANTHROPIC_API_KEY)")
     if missing:
         pytest.skip(f"LLM eval requires {', '.join(missing)} in the environment")
 

--- a/tests/integration/test_llm_evals.py
+++ b/tests/integration/test_llm_evals.py
@@ -64,20 +64,21 @@ async def test_eval_case(case: dict) -> None:
         f"tool loop hit max iterations without finishing; tools called={run.tool_names}"
     )
 
-    # Read-only + dry-run scope: no eval may perform a real YNAB write.
+    # The server runs in Code Mode (its default and target surface): the public
+    # tools are `search` + `execute`, and the YNAB helpers are reached as Python
+    # `ynab.read.*` / `ynab.write.*` inside `execute`. The model must actually
+    # engage that surface rather than answer from prior knowledge.
+    assert run.tool_names, f"eval engaged no tools; answer={run.final_text!r}"
+
+    # Read-only + dry-run scope. Two layers keep this safe against a live budget:
+    #   1. Server-enforced (primary): code_mode_mutations_enabled defaults to
+    #      False, so `ynab.write.*` is blocked by the runner (AST audit + dispatch
+    #      fail-closed) and hidden from the Code Mode spec.
+    #   2. Defensive (this assert): if someone disabled Code Mode tool replacement
+    #      (the escape hatch), the legacy direct write tools become callable — none
+    #      should ever be invoked under the eval config.
     illegal_writes = [t for t in run.tool_names if t in YNAB_WRITE_TOOLS]
     assert not illegal_writes, f"eval performed disallowed YNAB write(s): {illegal_writes}"
-
-    if case.get("category") == "read":
-        # A read task must actually consult YNAB rather than answer from prior knowledge.
-        assert run.tool_names, f"read eval made no tool calls; answer={run.final_text!r}"
-    elif case.get("category") == "mutation":
-        # Dry-run prompts must not reach a write via the code-mode `execute` sandbox,
-        # which would bypass the write-tool gate above.
-        assert "execute" not in run.tool_names, (
-            "dry-run eval used the code-mode `execute` tool, which can perform live "
-            f"mutations and bypasses the write gate; tools={run.tool_names}"
-        )
 
     passed, reason = await judge_answer(
         case["prompt"], case["expected_output"], run.final_text, model=judge_model

--- a/tests/integration/test_llm_evals.py
+++ b/tests/integration/test_llm_evals.py
@@ -1,0 +1,89 @@
+"""LLM-driven evals: Claude uses the live mcp-ynab tools to satisfy prompts.
+
+Marked ``integration`` + ``eval`` (excluded from the default run). Requires
+``ANTHROPIC_API_KEY`` and ``YNAB_API_KEY``; these cost API tokens and run
+against whatever budget the YNAB key points at. Scope is read-only + dry-run —
+the structural gate below fails the test if any eval performs a real YNAB
+write, so it is safe to run against a live budget.
+
+Run with::
+
+    YNAB_API_KEY=... ANTHROPIC_API_KEY=... uv run pytest -m eval
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.integration._llm_eval_harness import (
+    DEFAULT_EVAL_MODEL,
+    DEFAULT_JUDGE_MODEL,
+    YNAB_WRITE_TOOLS,
+    drive_prompt,
+    judge_answer,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.eval]
+
+_EVALS_PATH = Path(__file__).resolve().parents[2] / "evals" / "evals.json"
+
+
+def _load_eval_cases() -> list[dict]:
+    if not _EVALS_PATH.exists():
+        return []
+    return json.loads(_EVALS_PATH.read_text())["evals"]
+
+
+_EVAL_CASES = _load_eval_cases()
+
+
+def _require_eval_keys() -> None:
+    missing = [k for k in ("ANTHROPIC_API_KEY", "YNAB_API_KEY") if not os.getenv(k)]
+    if missing:
+        pytest.skip(f"LLM eval requires {', '.join(missing)} in the environment")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    _EVAL_CASES,
+    ids=[f"{c['id']}-{c['name']}" for c in _EVAL_CASES],
+)
+async def test_eval_case(case: dict) -> None:
+    _require_eval_keys()
+    model = os.getenv("EVAL_MODEL", DEFAULT_EVAL_MODEL)
+    judge_model = os.getenv("EVAL_JUDGE_MODEL", DEFAULT_JUDGE_MODEL)
+
+    run = await drive_prompt(case["prompt"], model=model)
+
+    assert not run.stopped_early, (
+        f"tool loop hit max iterations without finishing; tools called={run.tool_names}"
+    )
+
+    # Read-only + dry-run scope: no eval may perform a real YNAB write.
+    illegal_writes = [t for t in run.tool_names if t in YNAB_WRITE_TOOLS]
+    assert not illegal_writes, f"eval performed disallowed YNAB write(s): {illegal_writes}"
+
+    if case.get("category") == "read":
+        # A read task must actually consult YNAB rather than answer from prior knowledge.
+        assert run.tool_names, f"read eval made no tool calls; answer={run.final_text!r}"
+    elif case.get("category") == "mutation":
+        # Dry-run prompts must not reach a write via the code-mode `execute` sandbox,
+        # which would bypass the write-tool gate above.
+        assert "execute" not in run.tool_names, (
+            "dry-run eval used the code-mode `execute` tool, which can perform live "
+            f"mutations and bypasses the write gate; tools={run.tool_names}"
+        )
+
+    passed, reason = await judge_answer(
+        case["prompt"], case["expected_output"], run.final_text, model=judge_model
+    )
+    assert passed, (
+        f"judge rejected the answer for eval {case['id']} ({case['name']}): {reason}\n"
+        f"--- tools called ---\n{run.tool_names}\n"
+        f"--- final answer ---\n{run.final_text}"
+    )

--- a/tests/integration/test_llm_evals.py
+++ b/tests/integration/test_llm_evals.py
@@ -80,6 +80,19 @@ async def test_eval_case(case: dict) -> None:
     illegal_writes = [t for t in run.tool_names if t in YNAB_WRITE_TOOLS]
     assert not illegal_writes, f"eval performed disallowed YNAB write(s): {illegal_writes}"
 
+    # Structural wrong-tool-path check (read tasks only). In Code Mode the YNAB
+    # call lives in the Python passed to `execute`, so inspect that code rather
+    # than the tool name. Any one of the listed read ops is acceptable. Mutation
+    # tasks can't be checked this way — the write ops are hidden in read-only
+    # Code Mode — so the LLM judge carries those.
+    expected_refs = case.get("expected_code_refs") or []
+    if expected_refs:
+        executed_code = "\n".join(str(tc.arguments.get("code", "")) for tc in run.tool_calls)
+        assert any(ref in executed_code for ref in expected_refs), (
+            f"expected the executed code to call one of {expected_refs}; "
+            f"executed code was:\n{executed_code[:800]}"
+        )
+
     passed, reason = await judge_answer(
         case["prompt"], case["expected_output"], run.final_text, model=judge_model
     )

--- a/tests/integration/test_llm_evals.py
+++ b/tests/integration/test_llm_evals.py
@@ -24,6 +24,7 @@ from tests.integration._llm_eval_harness import (
     DEFAULT_JUDGE_MODEL,
     YNAB_WRITE_TOOLS,
     drive_prompt,
+    eval_api_key,
     judge_answer,
 )
 
@@ -42,7 +43,11 @@ _EVAL_CASES = _load_eval_cases()
 
 
 def _require_eval_keys() -> None:
-    missing = [k for k in ("ANTHROPIC_API_KEY", "YNAB_API_KEY") if not os.getenv(k)]
+    missing = []
+    if not eval_api_key():
+        missing.append("ANTHROPIC_API_KEY (or EVAL_ANTHROPIC_API_KEY)")
+    if not os.getenv("YNAB_API_KEY"):
+        missing.append("YNAB_API_KEY")
     if missing:
         pytest.skip(f"LLM eval requires {', '.join(missing)} in the environment")
 

--- a/tests/integration/test_llm_evals.py
+++ b/tests/integration/test_llm_evals.py
@@ -1,7 +1,9 @@
 """LLM-driven evals: Claude uses the live mcp-ynab tools to satisfy prompts.
 
-Marked ``integration`` + ``eval`` (excluded from the default run). Requires
-``ANTHROPIC_API_KEY`` and ``YNAB_API_KEY``; these cost API tokens and run
+Marked ``integration`` + ``eval`` (excluded from the default run). Always needs
+``YNAB_API_KEY``; the ``messages-api`` driver additionally needs an Anthropic
+key (``EVAL_ANTHROPIC_API_KEY`` or ``ANTHROPIC_API_KEY``) and costs API tokens,
+while the ``agent-sdk`` driver authenticates via your Claude subscription. Runs
 against whatever budget the YNAB key points at. Scope is read-only + dry-run —
 the structural gate below fails the test if any eval performs a real YNAB
 write, so it is safe to run against a live budget.
@@ -9,6 +11,7 @@ write, so it is safe to run against a live budget.
 Run with::
 
     YNAB_API_KEY=... ANTHROPIC_API_KEY=... uv run pytest -m eval
+    YNAB_API_KEY=... EVAL_DRIVER=agent-sdk uv run pytest -m eval   # subscription
 """
 
 from __future__ import annotations

--- a/tests/integration/test_read_only.py
+++ b/tests/integration/test_read_only.py
@@ -106,7 +106,7 @@ async def test_get_month_renders_snapshot_for_latest_populated_month(
 
     cfg = Configuration(access_token=os.environ["YNAB_API_KEY"])
     with ApiClient(cfg) as raw_client:
-        months = MonthsApi(raw_client).get_budget_months(integration_first_budget_id).data.months
+        months = MonthsApi(raw_client).get_plan_months(integration_first_budget_id).data.months
     if not months:
         pytest.skip("Budget has no month data")
     latest_iso = months[0].month.isoformat()

--- a/tests/stubs.golden.pyi
+++ b/tests/stubs.golden.pyi
@@ -268,8 +268,11 @@ class WriteNamespace:
         name: str | None = ...,
         note: str | None = ...,
         category_group_id: str | None = ...,
+        goal_target: float | None = ...,
+        goal_target_date: str | None = ...,
+        goal_needs_whole_amount: bool | None = ...,
     ) -> str:
-        """Rename a category, update its note, or move it to a different category group."""
+        """Rename a category, edit its note/group, or set its recurring monthly goal."""
         ...
 
     async def update_transaction(

--- a/tests/test_budgeting_core.py
+++ b/tests/test_budgeting_core.py
@@ -368,12 +368,79 @@ async def test_update_category_move_group(
     cat = _category_mock("c-1", "Groceries")
     mock_ynab_apis.categories.update_category.return_value = _resp(category=cat)
 
-    result = await server.update_category("budget-1", "c-1", category_group_id="group-2")
+    group_id = "22222222-2222-2222-2222-222222222222"
+    result = await server.update_category("budget-1", "c-1", category_group_id=group_id)
 
     assert "moved to group" in result
     args = mock_ynab_apis.categories.update_category.call_args
     _, _, wrapper = args.args
-    assert wrapper.category.category_group_id == "group-2"
+    # SDK parses category_group_id into a uuid.UUID, so compare by string value.
+    assert str(wrapper.category.category_group_id) == group_id
+
+
+@pytest.mark.asyncio
+async def test_update_category_sets_goal_target_in_milliunits(
+    mock_ynab_apis: SimpleNamespace,
+) -> None:
+    cat = _category_mock("c-1", "Vacation")
+    mock_ynab_apis.categories.update_category.return_value = _resp(category=cat)
+
+    result = await server.update_category("budget-1", "c-1", goal_target=150.0)
+
+    assert "goal target set to $150.00" in result
+    _, _, wrapper = mock_ynab_apis.categories.update_category.call_args.args
+    # Dollars are converted to YNAB milliunits (x1000).
+    assert wrapper.category.goal_target == 150_000
+
+
+@pytest.mark.asyncio
+async def test_update_category_sets_goal_target_date(
+    mock_ynab_apis: SimpleNamespace,
+) -> None:
+    cat = _category_mock("c-1", "Vacation")
+    mock_ynab_apis.categories.update_category.return_value = _resp(category=cat)
+
+    result = await server.update_category("budget-1", "c-1", goal_target_date="2026-07-01")
+
+    assert "goal target date set to `2026-07-01`" in result
+    _, _, wrapper = mock_ynab_apis.categories.update_category.call_args.args
+    # SDK coerces the ISO string into a datetime.date.
+    assert wrapper.category.goal_target_date == date(2026, 7, 1)
+
+
+@pytest.mark.asyncio
+async def test_update_category_sets_goal_needs_whole_amount(
+    mock_ynab_apis: SimpleNamespace,
+) -> None:
+    cat = _category_mock("c-1", "Vacation")
+    mock_ynab_apis.categories.update_category.return_value = _resp(category=cat)
+
+    result = await server.update_category("budget-1", "c-1", goal_needs_whole_amount=True)
+
+    assert "goal mode set to Set Aside" in result
+    _, _, wrapper = mock_ynab_apis.categories.update_category.call_args.args
+    assert wrapper.category.goal_needs_whole_amount is True
+
+    # False selects the "Refill" mode.
+    result = await server.update_category("budget-1", "c-1", goal_needs_whole_amount=False)
+    assert "goal mode set to Refill" in result
+
+
+@pytest.mark.asyncio
+async def test_update_category_omits_unset_fields_from_payload(
+    mock_ynab_apis: SimpleNamespace,
+) -> None:
+    """Only-provided fields reach the wire; omitted fields must not clear data."""
+    cat = _category_mock("c-1", "Vacation")
+    mock_ynab_apis.categories.update_category.return_value = _resp(category=cat)
+
+    await server.update_category("budget-1", "c-1", goal_target=25.0)
+
+    _, _, wrapper = mock_ynab_apis.categories.update_category.call_args.args
+    # ExistingCategory serializes with exclude_none, so name/note/group and the
+    # other goal fields are absent from the payload — YNAB leaves them untouched.
+    payload = wrapper.category.to_dict()
+    assert payload == {"goal_target": 25_000}
 
 
 @pytest.mark.asyncio

--- a/tests/test_budgeting_core.py
+++ b/tests/test_budgeting_core.py
@@ -101,7 +101,7 @@ async def test_get_month_renders_summary_and_groups(
             category_group_name="Bills",
         ),
     ]
-    mock_ynab_apis.months.get_budget_month.return_value = _resp(
+    mock_ynab_apis.months.get_plan_month.return_value = _resp(
         month=_month_detail_mock(categories=cats)
     )
 
@@ -113,7 +113,7 @@ async def test_get_month_renders_summary_and_groups(
     assert "## Bills" in result and "## Daily" in result
     assert "Groceries" in result and "Rent" in result
     # Verify SDK call shape
-    args = mock_ynab_apis.months.get_budget_month.call_args
+    args = mock_ynab_apis.months.get_plan_month.call_args
     assert args.args[0] == "budget-1"
     assert args.args[1] == date.today().replace(day=1)
 
@@ -122,14 +122,14 @@ async def test_get_month_renders_summary_and_groups(
 async def test_get_month_accepts_explicit_iso_date(
     mock_ynab_apis: SimpleNamespace,
 ) -> None:
-    mock_ynab_apis.months.get_budget_month.return_value = _resp(
+    mock_ynab_apis.months.get_plan_month.return_value = _resp(
         month=_month_detail_mock(month_iso="2026-04-01")
     )
 
     result = await server.get_month("budget-1", "2026-04-01")
 
     assert "2026-04-01" in result
-    args = mock_ynab_apis.months.get_budget_month.call_args
+    args = mock_ynab_apis.months.get_plan_month.call_args
     assert args.args[1] == date(2026, 4, 1)
 
 
@@ -137,7 +137,7 @@ async def test_get_month_accepts_explicit_iso_date(
 async def test_get_month_handles_missing_age_of_money(
     mock_ynab_apis: SimpleNamespace,
 ) -> None:
-    mock_ynab_apis.months.get_budget_month.return_value = _resp(
+    mock_ynab_apis.months.get_plan_month.return_value = _resp(
         month=_month_detail_mock(age_of_money=None)
     )
 
@@ -292,7 +292,7 @@ async def test_move_money_rejects_same_source_and_destination(
 async def test_current_month_resource_returns_text_content(
     mock_ynab_apis: SimpleNamespace,
 ) -> None:
-    mock_ynab_apis.months.get_budget_month.return_value = _resp(
+    mock_ynab_apis.months.get_plan_month.return_value = _resp(
         month=_month_detail_mock(month_iso="2026-05-01")
     )
 
@@ -301,7 +301,7 @@ async def test_current_month_resource_returns_text_content(
     assert isinstance(result, list) and len(result) == 1
     assert result[0].type == "text"
     assert "# YNAB Month: 2026-05-01" in result[0].text
-    args = mock_ynab_apis.months.get_budget_month.call_args
+    args = mock_ynab_apis.months.get_plan_month.call_args
     assert args.args[1] == date.today().replace(day=1)
 
 
@@ -309,7 +309,7 @@ async def test_current_month_resource_returns_text_content(
 async def test_arbitrary_month_resource_uses_iso_date(
     mock_ynab_apis: SimpleNamespace,
 ) -> None:
-    mock_ynab_apis.months.get_budget_month.return_value = _resp(
+    mock_ynab_apis.months.get_plan_month.return_value = _resp(
         month=_month_detail_mock(month_iso="2026-03-01")
     )
 
@@ -317,7 +317,7 @@ async def test_arbitrary_month_resource_uses_iso_date(
 
     assert isinstance(result, list) and len(result) == 1
     assert "2026-03-01" in result[0].text
-    args = mock_ynab_apis.months.get_budget_month.call_args
+    args = mock_ynab_apis.months.get_plan_month.call_args
     assert args.args[1] == date(2026, 3, 1)
 
 
@@ -447,6 +447,31 @@ async def test_update_category_omits_unset_fields_from_payload(
 async def test_update_category_requires_at_least_one_field() -> None:
     with pytest.raises(ValueError, match="At least one of"):
         await server.update_category("budget-1", "c-1")
+
+
+@pytest.mark.asyncio
+async def test_update_category_rejects_empty_goal_target_date() -> None:
+    # An empty string slips past the "at least one field" guard but parses to
+    # nothing — surface it as a clear error rather than a silent no-op update.
+    with pytest.raises(ValueError):
+        await server.update_category("budget-1", "c-1", goal_target_date="")
+
+
+def test_cache_categories_survives_uuid_category_ids(tmp_path) -> None:
+    """ynab v4 Category.to_dict() yields uuid.UUID ids; the cache must persist
+    them without a json.dump TypeError (regression for the v4 SDK bump)."""
+    import uuid
+
+    from mcp_ynab.server import YNABResources
+
+    cid = uuid.uuid4()
+    YNABResources(config_dir=tmp_path).cache_categories(
+        "b-1", [{"id": cid, "name": "Groceries", "category_group_name": "Food"}]
+    )
+    # A fresh instance reloads from disk — a write crash (pre-fix) or a raw UUID
+    # on disk would surface here.
+    reloaded = YNABResources(config_dir=tmp_path).get_cached_category_records("b-1")
+    assert reloaded and reloaded[0]["id"] == str(cid)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -3,7 +3,7 @@
 import os
 
 import pytest
-from ynab.api.budgets_api import BudgetsApi
+from ynab.api.plans_api import PlansApi
 
 
 @pytest.mark.integration
@@ -19,10 +19,10 @@ def test_environment_variables():
 @pytest.mark.integration
 def test_ynab_api_connection(ynab_client):
     """Test that we can connect to the YNAB API."""
-    budgets_api = BudgetsApi(ynab_client)
-    budgets_response = budgets_api.get_budgets()
-    assert budgets_response.data.budgets is not None
-    assert len(budgets_response.data.budgets) > 0
+    plans_api = PlansApi(ynab_client)
+    budgets_response = plans_api.get_plans()
+    assert budgets_response.data.plans is not None
+    assert len(budgets_response.data.plans) > 0
 
 
 def test_preferences_files_exist():

--- a/tests/test_llm_eval_harness.py
+++ b/tests/test_llm_eval_harness.py
@@ -252,3 +252,47 @@ async def test_drive_prompt_marks_stopped_early_when_loop_never_finishes(
 
     assert run.stopped_early is True
     assert len(run.tool_calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# agent-sdk driver — config/plumbing only (no subscription, no network).
+# ---------------------------------------------------------------------------
+
+
+def test_current_driver_default_and_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVAL_DRIVER", raising=False)
+    assert harness.current_driver() == "messages-api"
+    monkeypatch.setenv("EVAL_DRIVER", "agent-sdk")
+    assert harness.current_driver() == "agent-sdk"
+
+
+def test_normalize_tool_name_strips_mcp_prefix() -> None:
+    assert harness._normalize_tool_name("mcp__ynab__execute") == "execute"
+    assert harness._normalize_tool_name("mcp__ynab__search") == "search"
+    assert harness._normalize_tool_name("Bash") == "Bash"  # built-ins unchanged
+
+
+def test_subscription_env_forces_subscription_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVAL_CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    env = harness._subscription_env()
+    # Blanks out the vars that would otherwise outrank the claude CLI login.
+    assert env["ANTHROPIC_API_KEY"] == ""
+    assert env["ANTHROPIC_AUTH_TOKEN"] == ""
+    assert env["CLAUDE_CODE_USE_BEDROCK"] == "false"
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env  # falls back to existing login
+    monkeypatch.setenv("EVAL_CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-xyz")
+    assert harness._subscription_env()["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-xyz"
+
+
+def test_agent_sdk_options_shape() -> None:
+    opts = harness.agent_sdk_options("claude-sonnet-4-6")
+    assert opts.model == "claude-sonnet-4-6"
+    assert "ynab" in opts.mcp_servers
+    assert opts.mcp_servers["ynab"]["type"] == "stdio"
+    # Only the Code Mode tools are pre-approved; unlisted tools are denied.
+    assert opts.allowed_tools == ["mcp__ynab__execute", "mcp__ynab__search"]
+    assert opts.permission_mode == "dontAsk"
+    # Isolated from the user's global Claude Code config for reproducibility.
+    assert opts.setting_sources == []
+    assert opts.strict_mcp_config is True

--- a/tests/test_llm_eval_harness.py
+++ b/tests/test_llm_eval_harness.py
@@ -7,8 +7,12 @@ regression in tool conversion or verdict parsing is caught cheaply.
 
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
 
+import pytest
+
+from tests.integration import _llm_eval_harness as harness
 from tests.integration._llm_eval_harness import (
     YNAB_WRITE_TOOLS,
     EvalRun,
@@ -90,3 +94,159 @@ def test_write_tools_cover_update_category() -> None:
     # The feature this PR ships is a YNAB write — the dry-run gate must catch it.
     assert "update_category" in YNAB_WRITE_TOOLS
     assert "create_transaction" in YNAB_WRITE_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# drive_prompt loop logic — fake Anthropic client + fake MCP session, no keys.
+# Verifies tool-call capture, result feedback shape, and termination. Does NOT
+# cover real-API acceptance of round-tripped content blocks (SDK-version
+# sensitive); that needs a live `task test:eval` run.
+# ---------------------------------------------------------------------------
+
+
+class _Block:
+    """Minimal stand-in for an Anthropic content block."""
+
+    def __init__(self, **kw: object) -> None:
+        self.__dict__.update(kw)
+
+    def model_dump(self) -> dict:
+        return dict(self.__dict__)
+
+
+class _Resp:
+    def __init__(self, stop_reason: str, content: list) -> None:
+        self.stop_reason = stop_reason
+        self.content = content
+
+
+class _FakeMessages:
+    def __init__(self, responses: list, calls: list) -> None:
+        self._responses = list(responses)
+        self._calls = calls
+
+    async def create(self, **kwargs: object):
+        self._calls.append(kwargs)
+        return self._responses.pop(0)
+
+
+class _FakeAnthropic:
+    def __init__(self, responses: list, calls: list) -> None:
+        self.messages = _FakeMessages(responses, calls)
+
+
+def _make_fake_session_cls(tool_log: list):
+    class _FakeSession:
+        def __init__(self, _read: object, _write: object) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a: object) -> bool:
+            return False
+
+        async def initialize(self) -> None:
+            pass
+
+        async def list_tools(self):
+            tool = SimpleNamespace(
+                name="execute",
+                description="run code",
+                inputSchema={"type": "object", "properties": {"code": {"type": "string"}}},
+            )
+            return SimpleNamespace(tools=[tool])
+
+        async def call_tool(self, name: str, arguments: dict):
+            tool_log.append((name, arguments))
+            return SimpleNamespace(content=[_Block(type="text", text="budgets: [Personal]")])
+
+    return _FakeSession
+
+
+def _make_fake_stdio_client():
+    @contextlib.asynccontextmanager
+    async def _fake(_params: object):
+        yield ("read-stream", "write-stream")
+
+    return _fake
+
+
+@pytest.mark.asyncio
+async def test_drive_prompt_runs_tool_loop_and_returns_final_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import anthropic
+    import mcp
+    import mcp.client.stdio
+
+    create_calls: list = []
+    responses = [
+        _Resp(
+            "tool_use",
+            [
+                _Block(
+                    type="tool_use",
+                    name="execute",
+                    input={"code": "return await ynab.read.get_budgets()"},
+                    id="tu1",
+                )
+            ],
+        ),
+        _Resp("end_turn", [_Block(type="text", text="You have 1 budget: Personal.")]),
+    ]
+    tool_log: list = []
+
+    monkeypatch.setattr(
+        anthropic, "AsyncAnthropic", lambda: _FakeAnthropic(responses, create_calls)
+    )
+    monkeypatch.setattr(mcp, "ClientSession", _make_fake_session_cls(tool_log))
+    monkeypatch.setattr(mcp.client.stdio, "stdio_client", _make_fake_stdio_client())
+
+    run = await harness.drive_prompt("How many budgets do I have?", model="test-model")
+
+    # Loop terminated on end_turn, captured the tool call, returned the answer.
+    assert run.stopped_early is False
+    assert run.tool_names == ["execute"]
+    assert run.tool_calls[0].arguments == {"code": "return await ynab.read.get_budgets()"}
+    assert run.final_text == "You have 1 budget: Personal."
+
+    # The tool was dispatched to the MCP session with the model's args.
+    assert tool_log == [("execute", {"code": "return await ynab.read.get_budgets()"})]
+
+    # First call carried the Code Mode system prompt; the second fed the tool
+    # result back as a tool_result tied to the originating tool_use id.
+    assert create_calls[0]["system"] == harness.CODE_MODE_SYSTEM
+    tool_results = create_calls[1]["messages"][-1]["content"]
+    assert tool_results[0]["type"] == "tool_result"
+    assert tool_results[0]["tool_use_id"] == "tu1"
+    assert "budgets: [Personal]" in tool_results[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_drive_prompt_marks_stopped_early_when_loop_never_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import anthropic
+    import mcp
+    import mcp.client.stdio
+
+    # Always returns tool_use → loop should hit max_iterations and flag it.
+    def _always_tool_use(**_kwargs: object):
+        return _Resp(
+            "tool_use",
+            [_Block(type="tool_use", name="execute", input={"code": "pass"}, id="t")],
+        )
+
+    class _Loop:
+        async def create(self, **kwargs: object):
+            return _always_tool_use(**kwargs)
+
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", lambda: SimpleNamespace(messages=_Loop()))
+    monkeypatch.setattr(mcp, "ClientSession", _make_fake_session_cls([]))
+    monkeypatch.setattr(mcp.client.stdio, "stdio_client", _make_fake_stdio_client())
+
+    run = await harness.drive_prompt("loop forever", model="test-model", max_iterations=3)
+
+    assert run.stopped_early is True
+    assert len(run.tool_calls) == 3

--- a/tests/test_llm_eval_harness.py
+++ b/tests/test_llm_eval_harness.py
@@ -198,7 +198,7 @@ async def test_drive_prompt_runs_tool_loop_and_returns_final_text(
     tool_log: list = []
 
     monkeypatch.setattr(
-        anthropic, "AsyncAnthropic", lambda: _FakeAnthropic(responses, create_calls)
+        anthropic, "AsyncAnthropic", lambda **_kw: _FakeAnthropic(responses, create_calls)
     )
     monkeypatch.setattr(mcp, "ClientSession", _make_fake_session_cls(tool_log))
     monkeypatch.setattr(mcp.client.stdio, "stdio_client", _make_fake_stdio_client())
@@ -242,7 +242,9 @@ async def test_drive_prompt_marks_stopped_early_when_loop_never_finishes(
         async def create(self, **kwargs: object):
             return _always_tool_use(**kwargs)
 
-    monkeypatch.setattr(anthropic, "AsyncAnthropic", lambda: SimpleNamespace(messages=_Loop()))
+    monkeypatch.setattr(
+        anthropic, "AsyncAnthropic", lambda **_kw: SimpleNamespace(messages=_Loop())
+    )
     monkeypatch.setattr(mcp, "ClientSession", _make_fake_session_cls([]))
     monkeypatch.setattr(mcp.client.stdio, "stdio_client", _make_fake_stdio_client())
 

--- a/tests/test_llm_eval_harness.py
+++ b/tests/test_llm_eval_harness.py
@@ -1,0 +1,92 @@
+"""Unit tests for the pure helpers in the LLM-eval harness.
+
+These run in the default suite — no API keys, no network. They cover the
+schema/parse plumbing that the (gated, costly) integration evals rely on, so a
+regression in tool conversion or verdict parsing is caught cheaply.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tests.integration._llm_eval_harness import (
+    YNAB_WRITE_TOOLS,
+    EvalRun,
+    ToolCall,
+    mcp_tools_to_anthropic,
+    parse_verdict,
+    tool_result_to_text,
+)
+
+
+def test_mcp_tools_to_anthropic_maps_fields() -> None:
+    tools = [
+        SimpleNamespace(
+            name="get_budgets",
+            description="List budgets",
+            inputSchema={"type": "object", "properties": {"x": {"type": "string"}}},
+        )
+    ]
+    [schema] = mcp_tools_to_anthropic(tools)
+    assert schema["name"] == "get_budgets"
+    assert schema["description"] == "List budgets"
+    assert schema["input_schema"]["properties"] == {"x": {"type": "string"}}
+
+
+def test_mcp_tools_to_anthropic_defaults_missing_schema_and_description() -> None:
+    tools = [SimpleNamespace(name="ping", description=None, inputSchema=None)]
+    [schema] = mcp_tools_to_anthropic(tools)
+    assert schema["description"] == ""
+    assert schema["input_schema"] == {"type": "object", "properties": {}}
+
+
+def test_tool_result_to_text_joins_text_blocks() -> None:
+    result = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="text", text="line one"),
+            SimpleNamespace(type="image"),  # no .text → skipped
+            SimpleNamespace(type="text", text="line two"),
+        ]
+    )
+    assert tool_result_to_text(result) == "line one\nline two"
+
+
+def test_tool_result_to_text_handles_empty() -> None:
+    assert tool_result_to_text(SimpleNamespace(content=None)) == ""
+
+
+def test_parse_verdict_reads_tool_use_block() -> None:
+    blocks = [
+        SimpleNamespace(type="text", text="thinking"),
+        SimpleNamespace(
+            type="tool_use",
+            name="record_verdict",
+            input={"passed": True, "reason": "matches expectation"},
+        ),
+    ]
+    passed, reason = parse_verdict(blocks)
+    assert passed is True
+    assert reason == "matches expectation"
+
+
+def test_parse_verdict_defaults_to_fail_when_absent() -> None:
+    passed, reason = parse_verdict([SimpleNamespace(type="text", text="no verdict here")])
+    assert passed is False
+    assert "did not return a verdict" in reason
+
+
+def test_eval_run_tool_names_property() -> None:
+    run = EvalRun(
+        final_text="done",
+        tool_calls=[
+            ToolCall("get_categories", {}),
+            ToolCall("get_transactions", {"budget_id": "b"}),
+        ],
+    )
+    assert run.tool_names == ["get_categories", "get_transactions"]
+
+
+def test_write_tools_cover_update_category() -> None:
+    # The feature this PR ships is a YNAB write — the dry-run gate must catch it.
+    assert "update_category" in YNAB_WRITE_TOOLS
+    assert "create_transaction" in YNAB_WRITE_TOOLS

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2490,6 +2490,108 @@ async def test_resolve_budget_id_persists_preference_when_requested(
     assert isolated.get_preferred_budget_id() == "a-b"
 
 
+# ---------------------------------------------------------------------------
+# ynab >=2.x UUID coercion regressions
+#
+# These push real ``uuid.UUID`` objects through the production paths that the
+# str-based mocks above cannot exercise. PlanSummary.id / Category.id /
+# Payee.id became uuid.UUID at the 2.0.0 SDK bump; the code must keep returning
+# / storing plain ``str`` (prefs + caches are JSON/str-typed).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_budget_id_coerces_uuid_id_to_str(
+    mock_ynab_apis: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from mcp_ynab.server import YNABResources
+
+    monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
+    bid = uuid.uuid4()
+    budget = MagicMock()
+    budget.id = bid
+    budget.name = "Personal"
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(plans=[budget])
+
+    result = await server._resolve_budget_id(client=object(), ctx=None)
+
+    assert isinstance(result, str)
+    assert result == str(bid)
+
+
+@pytest.mark.asyncio
+async def test_resolve_budget_id_persists_uuid_preference_as_str(
+    mock_ynab_apis: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from mcp_ynab.server import YNABResources
+
+    isolated = YNABResources(config_dir=tmp_path)
+    monkeypatch.setattr(server, "ynab_resources", isolated)
+    chosen_id = uuid.uuid4()
+    chosen = MagicMock()
+    chosen.id = chosen_id
+    chosen.name = "Work"
+    other = MagicMock()
+    other.id = uuid.uuid4()
+    other.name = "Personal"
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(plans=[other, chosen])
+
+    ctx = _FakeContext(_accept(index=2, set_as_preferred=True))
+    result = await server._resolve_budget_id(client=object(), ctx=ctx)
+
+    assert result == str(chosen_id)
+    stored = isolated.get_preferred_budget_id()
+    # default_budget_id is a str field on Preferences; a raw UUID would not
+    # round-trip through the JSON prefs store or the str-keyed cache.
+    assert isinstance(stored, str)
+    assert stored == str(chosen_id)
+
+
+def test_process_category_data_coerces_uuid_id_to_str() -> None:
+    from ynab.models.category import Category
+
+    from mcp_ynab.formatters import _process_category_data
+
+    cat = Category.model_construct(
+        id=uuid.uuid4(),
+        category_group_id=uuid.uuid4(),
+        name="Groceries",
+        budgeted=1000,
+        activity=-500,
+    )
+    cat_id, name, _budgeted, _activity = _process_category_data(cat)
+
+    assert isinstance(cat_id, str)
+    assert cat_id == str(cat.id)
+    assert name == "Groceries"
+
+
+@pytest.mark.asyncio
+async def test_list_payees_resource_caches_uuid_ids_as_str(
+    mock_ynab_apis: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from mcp_ynab.resources import list_payees_resource
+    from mcp_ynab.server import YNABResources
+
+    isolated = YNABResources(config_dir=tmp_path)
+    monkeypatch.setattr(server, "ynab_resources", isolated)
+    pid = uuid.uuid4()
+    payee = MagicMock()
+    payee.id = pid
+    payee.name = "Trader Joe's"
+    payee.transfer_account_id = None
+    payee.deleted = False
+    mock_ynab_apis.payees.get_payees.return_value = _resp(payees=[payee])
+
+    # Must not raise: the cache writer uses plain json.dump, which a raw
+    # uuid.UUID would break.
+    result = await list_payees_resource("b-1")
+
+    records = isolated.get_cached_payee_records("b-1")
+    assert records == [{"id": str(pid), "name": "Trader Joe's", "transfer_account_id": None}]
+    assert "Trader Joe's" in result[0].text
+
+
 @pytest.mark.asyncio
 async def test_resolve_budget_id_raises_on_decline(
     mock_ynab_apis: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, tmp_path

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,6 +8,7 @@ SDK objects.
 
 from __future__ import annotations
 
+import uuid
 from datetime import date, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -26,6 +27,16 @@ from mcp_ynab.state import Preferences
 # ---------------------------------------------------------------------------
 # Helpers for building API responses
 # ---------------------------------------------------------------------------
+
+
+def _uuid(label: str) -> str:
+    """Deterministic valid UUID string for a readable label.
+
+    ynab SDK >=2.0 validates id fields (account_id, category_id, payee_id) as
+    UUIDs, so tests must feed real UUIDs wherever a value flows into SDK model
+    construction. uuid5 keeps them stable and debuggable per label.
+    """
+    return str(uuid.uuid5(uuid.NAMESPACE_OID, label))
 
 
 def _resp(**data_kwargs: object) -> MagicMock:
@@ -143,8 +154,8 @@ def _category_group_mock(name: str, categories: list[MagicMock]) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_get_budgets_renders_markdown_list(mock_ynab_apis: SimpleNamespace) -> None:
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[
             _budget_mock("b-1", "Personal"),
             _budget_mock("b-2", "Business"),
         ]
@@ -161,7 +172,7 @@ async def test_get_budgets_renders_markdown_list(mock_ynab_apis: SimpleNamespace
 
 @pytest.mark.asyncio
 async def test_get_budgets_handles_empty_budget_list(mock_ynab_apis: SimpleNamespace) -> None:
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(budgets=[])
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(plans=[])
 
     result = await server.get_budgets()
 
@@ -170,7 +181,7 @@ async def test_get_budgets_handles_empty_budget_list(mock_ynab_apis: SimpleNames
 
 @pytest.mark.asyncio
 async def test_get_budgets_propagates_api_exception(mock_ynab_apis: SimpleNamespace) -> None:
-    mock_ynab_apis.budgets.get_budgets.side_effect = ApiException(status=500, reason="Boom")
+    mock_ynab_apis.budgets.get_plans.side_effect = ApiException(status=500, reason="Boom")
 
     with pytest.raises(ApiException):
         await server.get_budgets()
@@ -190,9 +201,7 @@ async def test_get_account_balance_converts_milliunits_to_dollars(
     isolated = YNABResources(config_dir=tmp_path)
     monkeypatch.setattr(server, "ynab_resources", isolated)
 
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("b-1", "Personal")]
-    )
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(plans=[_budget_mock("b-1", "Personal")])
     account_response = _resp(account=SimpleNamespace(balance=125_000))
     mock_ynab_apis.accounts.get_account_by_id.return_value = account_response
 
@@ -219,7 +228,7 @@ async def test_get_account_balance_uses_preferred_budget_id_when_set(
 
     assert result == pytest.approx(42.0)
     # Preferred budget short-circuits the get_budgets fallback
-    mock_ynab_apis.budgets.get_budgets.assert_not_called()
+    mock_ynab_apis.budgets.get_plans.assert_not_called()
     mock_ynab_apis.accounts.get_account_by_id.assert_called_once_with("preferred-b", "acct-1")
 
 
@@ -232,8 +241,8 @@ async def test_get_account_balance_uses_only_budget_when_no_preference(
     isolated = YNABResources(config_dir=tmp_path)
     monkeypatch.setattr(server, "ynab_resources", isolated)
 
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("first-b", "Default")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("first-b", "Default")]
     )
     account_response = _resp(account=SimpleNamespace(balance=1_000))
     mock_ynab_apis.accounts.get_account_by_id.return_value = account_response
@@ -241,7 +250,7 @@ async def test_get_account_balance_uses_only_budget_when_no_preference(
     result = await server.get_account_balance("acct-1")
 
     assert result == pytest.approx(1.0)
-    mock_ynab_apis.budgets.get_budgets.assert_called_once()
+    mock_ynab_apis.budgets.get_plans.assert_called_once()
     mock_ynab_apis.accounts.get_account_by_id.assert_called_once_with("first-b", "acct-1")
 
 
@@ -1005,14 +1014,14 @@ async def test_create_transaction_uses_preferred_budget_id_when_set(
     mock_ynab_apis.transactions.create_transaction.return_value = _resp(transaction=created_txn)
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=-12.34,
         payee_name="Test Payee",
     )
 
     assert result == {"id": "new-txn", "amount": -12_340}
     # Should NOT have called get_budgets — preferred budget short-circuits
-    mock_ynab_apis.budgets.get_budgets.assert_not_called()
+    mock_ynab_apis.budgets.get_plans.assert_not_called()
     call = mock_ynab_apis.transactions.create_transaction.call_args
     assert call.args[0] == "preferred-b"
 
@@ -1026,21 +1035,21 @@ async def test_create_transaction_uses_only_budget_when_no_preference(
     isolated = YNABResources(config_dir=tmp_path)
     monkeypatch.setattr(server, "ynab_resources", isolated)
 
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("first-b", "Default")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("first-b", "Default")]
     )
     created_txn = MagicMock()
     created_txn.to_dict.return_value = {"id": "new-txn"}
     mock_ynab_apis.transactions.create_transaction.return_value = _resp(transaction=created_txn)
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=10.0,
         payee_name="Test Payee",
     )
 
     assert result == {"id": "new-txn"}
-    mock_ynab_apis.budgets.get_budgets.assert_called_once()
+    mock_ynab_apis.budgets.get_plans.assert_called_once()
     call = mock_ynab_apis.transactions.create_transaction.call_args
     assert call.args[0] == "first-b"
 
@@ -1058,7 +1067,7 @@ async def test_create_transaction_returns_empty_dict_when_response_missing(
     mock_ynab_apis.transactions.create_transaction.return_value = _resp(transaction=None)
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=5.0,
         payee_name="Test",
     )
@@ -1081,15 +1090,16 @@ async def test_create_transaction_accepts_payee_id_for_transfers(
     mock_ynab_apis.transactions.create_transaction.return_value = _resp(transaction=created_txn)
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=-25.0,
-        payee_id="transfer-payee-1",
+        payee_id=_uuid("transfer-payee-1"),
     )
 
     assert result == {"id": "new-transfer"}
     call = mock_ynab_apis.transactions.create_transaction.call_args
     posted = call.args[1].transaction
-    assert posted.payee_id == "transfer-payee-1"
+    # SDK parses payee_id into a uuid.UUID; compare by string value.
+    assert str(posted.payee_id) == _uuid("transfer-payee-1")
     assert posted.payee_name is None
 
 
@@ -1122,22 +1132,26 @@ async def test_bulk_categorize_updates_all_when_server_acks_every_id(
     )
 
     assignments = [
-        {"transaction_id": "t-1", "category_id": "c-coffee"},
-        {"transaction_id": "t-2", "category_id": "c-coffee"},
-        {"transaction_id": "t-3", "category_id": "c-rent"},
+        {"transaction_id": "t-1", "category_id": _uuid("c-coffee")},
+        {"transaction_id": "t-2", "category_id": _uuid("c-coffee")},
+        {"transaction_id": "t-3", "category_id": _uuid("c-rent")},
     ]
     result = await server.bulk_categorize("b-1", assignments)
 
     assert "# Bulk Categorize" in result
     assert "**3 of 3 updated**" in result
-    assert "t-1" in result and "c-coffee" in result and "Updated" in result
+    assert "t-1" in result and _uuid("c-coffee") in result and "Updated" in result
     mock_ynab_apis.transactions.update_transactions.assert_called_once()
     call = mock_ynab_apis.transactions.update_transactions.call_args
     assert call.args[0] == "b-1"
     payload = call.args[1]
     assert len(payload.transactions) == 3
     assert {t.id for t in payload.transactions} == {"t-1", "t-2", "t-3"}
-    assert {t.category_id for t in payload.transactions} == {"c-coffee", "c-rent"}
+    # SDK parses category_id into uuid.UUID; compare by string value.
+    assert {str(t.category_id) for t in payload.transactions} == {
+        _uuid("c-coffee"),
+        _uuid("c-rent"),
+    }
 
 
 @pytest.mark.asyncio
@@ -1147,8 +1161,8 @@ async def test_bulk_categorize_marks_unacked_ids_as_not_found(
     mock_ynab_apis.transactions.update_transactions.return_value = _resp(transaction_ids=["t-1"])
 
     assignments = [
-        {"transaction_id": "t-1", "category_id": "c-1"},
-        {"transaction_id": "t-bad", "category_id": "c-1"},
+        {"transaction_id": "t-1", "category_id": _uuid("c-1")},
+        {"transaction_id": "t-bad", "category_id": _uuid("c-1")},
     ]
     result = await server.bulk_categorize("b-1", assignments)
 
@@ -1174,9 +1188,9 @@ async def test_bulk_categorize_skips_invalid_entries_but_processes_valid_ones(
     mock_ynab_apis.transactions.update_transactions.return_value = _resp(transaction_ids=["t-good"])
 
     assignments = [
-        {"transaction_id": "t-good", "category_id": "c-1"},
+        {"transaction_id": "t-good", "category_id": _uuid("c-1")},
         {"transaction_id": "t-no-category"},
-        {"category_id": "c-1"},
+        {"category_id": _uuid("c-1")},
     ]
     result = await server.bulk_categorize("b-1", assignments)
 
@@ -1209,7 +1223,9 @@ async def test_bulk_categorize_propagates_api_exception(
     )
 
     with pytest.raises(ApiException):
-        await server.bulk_categorize("b-1", [{"transaction_id": "t-1", "category_id": "c-1"}])
+        await server.bulk_categorize(
+            "b-1", [{"transaction_id": "t-1", "category_id": _uuid("c-1")}]
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1567,8 +1583,8 @@ async def test_split_transaction_patches_with_subtransactions_when_sum_matches(
     server.PutTransactionWrapper = fake_wrapper  # type: ignore[assignment]
 
     splits = [
-        {"amount": -20.0, "category_id": "cat-food", "memo": "Groceries"},
-        {"amount": -10.0, "category_id": "cat-fun", "payee_name": "Sub-Payee"},
+        {"amount": -20.0, "category_id": _uuid("cat-food"), "memo": "Groceries"},
+        {"amount": -10.0, "category_id": _uuid("cat-fun"), "payee_name": "Sub-Payee"},
     ]
     result = await server.split_transaction("b-1", "t-1", splits)
 
@@ -1578,7 +1594,8 @@ async def test_split_transaction_patches_with_subtransactions_when_sum_matches(
     subs = captured["subtransactions"]
     assert len(subs) == 2
     assert [s.amount for s in subs] == [-20_000, -10_000]
-    assert subs[0].category_id == "cat-food"
+    # SDK parses category_id into uuid.UUID; compare by string value.
+    assert str(subs[0].category_id) == _uuid("cat-food")
     assert subs[0].memo == "Groceries"
     assert subs[1].payee_name == "Sub-Payee"
 
@@ -1600,8 +1617,8 @@ async def test_split_transaction_rejects_when_sum_does_not_match(
             "b-1",
             "t-1",
             [
-                {"amount": -20.0, "category_id": "cat-1"},
-                {"amount": -5.0, "category_id": "cat-2"},
+                {"amount": -20.0, "category_id": _uuid("cat-1")},
+                {"amount": -5.0, "category_id": _uuid("cat-2")},
             ],
         )
 
@@ -1645,7 +1662,7 @@ async def test_split_transaction_raises_when_parent_not_found(
         await server.split_transaction(
             "b-1",
             "t-missing",
-            [{"amount": -10.0, "category_id": "c-1"}],
+            [{"amount": -10.0, "category_id": _uuid("c-1")}],
         )
 
     mock_ynab_apis.transactions.update_transaction.assert_not_called()
@@ -1663,7 +1680,7 @@ async def test_split_transaction_propagates_non_404_api_exception(
         await server.split_transaction(
             "b-1",
             "t-1",
-            [{"amount": -10.0, "category_id": "c-1"}],
+            [{"amount": -10.0, "category_id": _uuid("c-1")}],
         )
 
 
@@ -1750,8 +1767,8 @@ def _budget_resource_mock(
 async def test_list_budgets_resource_renders_markdown_table(
     mock_ynab_apis: SimpleNamespace,
 ) -> None:
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[
             _budget_resource_mock("b-1", "Personal"),
             _budget_resource_mock("b-2", "Business", iso_code="EUR"),
         ]
@@ -1775,7 +1792,7 @@ async def test_list_budgets_resource_renders_markdown_table(
 async def test_list_budgets_resource_handles_empty_list(
     mock_ynab_apis: SimpleNamespace,
 ) -> None:
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(budgets=[])
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(plans=[])
 
     result = await server.list_budgets_resource()
 
@@ -1787,8 +1804,8 @@ async def test_list_budgets_resource_handles_empty_list(
 async def test_list_budgets_resource_filters_deleted_budgets(
     mock_ynab_apis: SimpleNamespace,
 ) -> None:
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[
             _budget_resource_mock("b-active", "Active"),
             _budget_resource_mock("b-deleted", "Old", deleted=True),
         ]
@@ -2005,7 +2022,7 @@ async def test_create_scheduled_transaction_basic(
     )
 
     result = await server.create_scheduled_transaction(
-        "b-1", "acct-1", -15.99, frequency="monthly", payee_name="Netflix"
+        "b-1", _uuid("acct-1"), -15.99, frequency="monthly", payee_name="Netflix"
     )
 
     assert "sched-abc" in result
@@ -2017,7 +2034,8 @@ async def test_create_scheduled_transaction_basic(
     budget_id, wrapper = call.args
     assert budget_id == "b-1"
     txn = wrapper.scheduled_transaction
-    assert txn.account_id == "acct-1"
+    # SDK parses account_id into a uuid.UUID; compare by string value.
+    assert str(txn.account_id) == _uuid("acct-1")
     assert txn.amount == -15990
     assert txn.payee_name == "Netflix"
     assert txn.frequency == "monthly"
@@ -2047,7 +2065,9 @@ async def test_create_scheduled_transaction_uses_start_date(
         scheduled_transaction=created
     )
 
-    await server.create_scheduled_transaction("b-1", "acct-1", -1500.00, start_date="2026-06-01")
+    await server.create_scheduled_transaction(
+        "b-1", _uuid("acct-1"), -1500.00, start_date="2026-06-01"
+    )
 
     call = mock_ynab_apis.scheduled_transactions.create_scheduled_transaction.call_args
     _, wrapper = call.args
@@ -2070,7 +2090,7 @@ async def test_create_scheduled_transaction_defaults_to_today(
         scheduled_transaction=created
     )
 
-    await server.create_scheduled_transaction("b-1", "acct-1", -50.00)
+    await server.create_scheduled_transaction("b-1", _uuid("acct-1"), -50.00)
 
     call = mock_ynab_apis.scheduled_transactions.create_scheduled_transaction.call_args
     _, wrapper = call.args
@@ -2378,7 +2398,7 @@ async def test_resolve_budget_id_returns_preferred_when_set(
     result = await server._resolve_budget_id(client=object(), ctx=None)
 
     assert result == "preferred-b"
-    mock_ynab_apis.budgets.get_budgets.assert_not_called()
+    mock_ynab_apis.budgets.get_plans.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -2389,8 +2409,8 @@ async def test_resolve_budget_id_short_circuits_single_budget(
 
     isolated = YNABResources(config_dir=tmp_path)
     monkeypatch.setattr(server, "ynab_resources", isolated)
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("only-b", "Only Budget")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("only-b", "Only Budget")]
     )
 
     ctx = _FakeContext(_accept(index=1))
@@ -2407,7 +2427,7 @@ async def test_resolve_budget_id_raises_when_no_budgets(
     from mcp_ynab.server import YNABResources
 
     monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(budgets=[])
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(plans=[])
 
     with pytest.raises(ValueError, match="No YNAB budgets"):
         await server._resolve_budget_id(client=object(), ctx=None)
@@ -2421,8 +2441,8 @@ async def test_resolve_budget_id_raises_when_multiple_and_no_ctx(
     from mcp_ynab.server import YNABResources
 
     monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
     )
 
     with pytest.raises(ValueError, match="no preferred budget"):
@@ -2437,8 +2457,8 @@ async def test_resolve_budget_id_elicits_and_returns_chosen(
 
     isolated = YNABResources(config_dir=tmp_path)
     monkeypatch.setattr(server, "ynab_resources", isolated)
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("first-b", "Personal"), _budget_mock("second-b", "Work")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("first-b", "Personal"), _budget_mock("second-b", "Work")]
     )
 
     ctx = _FakeContext(_accept(index=2))
@@ -2459,8 +2479,8 @@ async def test_resolve_budget_id_persists_preference_when_requested(
 
     isolated = YNABResources(config_dir=tmp_path)
     monkeypatch.setattr(server, "ynab_resources", isolated)
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
     )
 
     ctx = _FakeContext(_accept(index=1, set_as_preferred=True))
@@ -2477,8 +2497,8 @@ async def test_resolve_budget_id_raises_on_decline(
     from mcp_ynab.server import YNABResources
 
     monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
     )
 
     ctx = _FakeContext(SimpleNamespace(action="decline"))
@@ -2493,8 +2513,8 @@ async def test_resolve_budget_id_raises_on_cancel(
     from mcp_ynab.server import YNABResources
 
     monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
     )
 
     ctx = _FakeContext(SimpleNamespace(action="cancel"))
@@ -2509,8 +2529,8 @@ async def test_resolve_budget_id_raises_on_out_of_range_index(
     from mcp_ynab.server import YNABResources
 
     monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("a-b", "A"), _budget_mock("b-b", "B")]
     )
 
     ctx = _FakeContext(_accept(index=99))
@@ -2526,8 +2546,8 @@ async def test_create_transaction_elicits_when_multiple_budgets(
     from mcp_ynab.server import YNABResources
 
     monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("first-b", "A"), _budget_mock("second-b", "B")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("first-b", "A"), _budget_mock("second-b", "B")]
     )
     created_txn = MagicMock()
     created_txn.to_dict.return_value = {"id": "new-txn"}
@@ -2535,7 +2555,7 @@ async def test_create_transaction_elicits_when_multiple_budgets(
 
     ctx = _FakeContext(_accept(index=2))
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=10.0,
         payee_name="Test",
         confirm=False,
@@ -2554,8 +2574,8 @@ async def test_get_account_balance_elicits_when_multiple_budgets(
     from mcp_ynab.server import YNABResources
 
     monkeypatch.setattr(server, "ynab_resources", YNABResources(config_dir=tmp_path))
-    mock_ynab_apis.budgets.get_budgets.return_value = _resp(
-        budgets=[_budget_mock("first-b", "A"), _budget_mock("second-b", "B")]
+    mock_ynab_apis.budgets.get_plans.return_value = _resp(
+        plans=[_budget_mock("first-b", "A"), _budget_mock("second-b", "B")]
     )
     mock_ynab_apis.accounts.get_account_by_id.return_value = _resp(
         account=SimpleNamespace(balance=50_000)
@@ -2775,17 +2795,17 @@ async def test_create_transaction_elicits_category_when_ambiguous(
         "b-1",
         [
             {"id": "c-a", "name": "Groceries 🛒", "category_group_name": "Food"},
-            {"id": "c-b", "name": "Groceries (Household)", "category_group_name": "Bills"},
+            {"id": _uuid("c-b"), "name": "Groceries (Household)", "category_group_name": "Bills"},
         ],
     )
     monkeypatch.setattr(server, "ynab_resources", isolated)
     mock_ynab_apis.transactions.create_transaction.return_value = _resp(
-        transaction=SimpleNamespace(to_dict=lambda: {"id": "t-1", "category_id": "c-b"})
+        transaction=SimpleNamespace(to_dict=lambda: {"id": "t-1", "category_id": _uuid("c-b")})
     )
     ctx = _FakeContext(_accept_category(index=2))
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=12.34,
         payee_name="Trader Joe's",
         category_name="groceries",
@@ -2793,11 +2813,11 @@ async def test_create_transaction_elicits_category_when_ambiguous(
         ctx=ctx,
     )
 
-    assert result == {"id": "t-1", "category_id": "c-b"}
+    assert result == {"id": "t-1", "category_id": _uuid("c-b")}
     # The wrapper passed to YNAB carried our chosen category_id.
     args, _ = mock_ynab_apis.transactions.create_transaction.call_args
     wrapper = args[1]
-    assert wrapper.transaction.category_id == "c-b"
+    assert str(wrapper.transaction.category_id) == _uuid("c-b")
 
 
 # ---------------------------------------------------------------------------
@@ -2886,7 +2906,7 @@ async def test_create_transaction_skips_confirmation_when_no_ctx(
     )
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=5.0,
         payee_name="Cafe",
     )
@@ -2911,7 +2931,7 @@ async def test_create_transaction_skips_confirmation_when_confirm_false(
     ctx = _QueuedFakeContext([])  # would raise if any elicit happened
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=5.0,
         payee_name="Cafe",
         confirm=False,
@@ -2940,7 +2960,7 @@ async def test_create_transaction_skips_confirmation_when_pref_disabled(
     ctx = _QueuedFakeContext([])  # would raise if any elicit happened
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=-10.0,
         payee_name="Bookstore",
         confirm=True,  # per-call confirm=True, but preference overrides
@@ -2963,7 +2983,7 @@ async def test_create_transaction_posts_after_confirmation_accepted(
     isolated.set_preferred_budget_id("b-1")
     isolated.cache_categories(
         "b-1",
-        [{"id": "c-food", "name": "Groceries", "category_group_name": "Food"}],
+        [{"id": _uuid("c-food"), "name": "Groceries", "category_group_name": "Food"}],
     )
     monkeypatch.setattr(server, "ynab_resources", isolated)
     mock_ynab_apis.transactions.create_transaction.return_value = _resp(
@@ -2972,7 +2992,7 @@ async def test_create_transaction_posts_after_confirmation_accepted(
     ctx = _QueuedFakeContext([_accept_confirm(True)])
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=-12.34,
         payee_name="Trader Joe's",
         category_name="Groceries",
@@ -3002,7 +3022,7 @@ async def test_create_transaction_returns_cancelled_when_confirm_field_false(
     ctx = _QueuedFakeContext([_accept_confirm(False)])
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=10.0,
         payee_name="Cafe",
         ctx=ctx,
@@ -3025,7 +3045,7 @@ async def test_create_transaction_returns_cancelled_on_decline(
     ctx = _QueuedFakeContext([SimpleNamespace(action="decline", data=None)])
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=10.0,
         payee_name="Cafe",
         ctx=ctx,
@@ -3048,7 +3068,7 @@ async def test_create_transaction_returns_cancelled_on_cancel(
     ctx = _QueuedFakeContext([SimpleNamespace(action="cancel", data=None)])
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=10.0,
         payee_name="Cafe",
         ctx=ctx,
@@ -3071,24 +3091,24 @@ async def test_create_transaction_chains_category_then_confirmation(
         "b-1",
         [
             {"id": "c-a", "name": "Groceries 🛒", "category_group_name": "Food"},
-            {"id": "c-b", "name": "Groceries (Household)", "category_group_name": "Bills"},
+            {"id": _uuid("c-b"), "name": "Groceries (Household)", "category_group_name": "Bills"},
         ],
     )
     monkeypatch.setattr(server, "ynab_resources", isolated)
     mock_ynab_apis.transactions.create_transaction.return_value = _resp(
-        transaction=SimpleNamespace(to_dict=lambda: {"id": "t-1", "category_id": "c-b"})
+        transaction=SimpleNamespace(to_dict=lambda: {"id": "t-1", "category_id": _uuid("c-b")})
     )
     ctx = _QueuedFakeContext([_accept_category(index=2), _accept_confirm(True)])
 
     result = await server.create_transaction(
-        account_id="acct-1",
+        account_id=_uuid("acct-1"),
         amount=-25.0,
         payee_name="Target",
         category_name="groceries",
         ctx=ctx,
     )
 
-    assert result == {"id": "t-1", "category_id": "c-b"}
+    assert result == {"id": "t-1", "category_id": _uuid("c-b")}
     schemas = [c[1] for c in ctx.calls]
     assert schemas == [server._CategoryChoice, server._PostConfirmation]
     # Confirmation message reflects the *chosen* category, not the user's input.

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.20.0,<2.0.0" },
     { name = "pydantic", specifier = ">=2.10.0,<3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "ynab", specifier = ">=1.0.1,<2.0.0" },
+    { name = "ynab", specifier = ">=4.1.0,<5.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1047,15 +1047,16 @@ wheels = [
 
 [[package]]
 name = "ynab"
-version = "1.0.1"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "certifi" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/03/e20b5224ac3bb46a49f67273a1fdc13cca4f111afefb65a915d88d3a4a72/ynab-1.0.1.tar.gz", hash = "sha256:6c284673fe721c14261d926c0af5b3638a62bb10bde88d678ba9e9921e4ef00c", size = 66790, upload-time = "2024-12-31T21:03:52.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/bf/ed29beabe8df208f7f6c6829d83b0d6fc1fb2634d1636e941bd5132dde21/ynab-4.1.0.tar.gz", hash = "sha256:9623dda46aa1c9e9e7e4ff24efe08f0041bb8dab9839fc38c76719d7c00c1125", size = 76375, upload-time = "2026-04-15T21:58:15.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/1a/f9365e4f0f8f45aae503b30db32da71d524db47801c34b88b7864aa07dc2/ynab-1.0.1-py3-none-any.whl", hash = "sha256:9592ee05b4370a7d6ef83366cc598e94aafeaf751cc469a4bd89ef6aa324c67a", size = 205182, upload-time = "2024-12-31T21:03:51.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8f/96b9f962cca0cbea056d8c0304fd0d2021fa0a42627835ed9a98bdcbab95/ynab-4.1.0-py3-none-any.whl", hash = "sha256:872a7ecf19b82ac967de86b1a71af3760b32ebec7b6bf238df8e550fa444dbfd", size = 269792, upload-time = "2026-04-15T21:58:16.998Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,24 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.2.104"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/14/0da3c38ba2fd8dd621bbc458d032eb77f75e745ae6d7b57be31c720c336b/claude_agent_sdk-0.2.104.tar.gz", hash = "sha256:b763b162337dc805916896e460f6c6d813523c9d0a6426b5b52c99c6ca17d740", size = 255616, upload-time = "2026-06-17T22:21:30.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/83/0b60439033401b4337d40f58c126b558917e79348ae67d5da20967e1abe0/claude_agent_sdk-0.2.104-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5852b7c0d423acf3e3ea94fbd61ee4315e0137aa836c22cf304b954db6124857", size = 64266654, upload-time = "2026-06-17T22:21:34.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c3/21bfb36920a705f6e17ab4d613beca47b1955ee0c281c605418d694ab5e9/claude_agent_sdk-0.2.104-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:1296cb27a53f8a8fce653b7ff19717ba35b2e4373ef7a534c8138f149160c57d", size = 67615132, upload-time = "2026-06-17T22:21:39.763Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/c24fe8676a4bf58ee6a0651af914e058bf9acdbab9548bde711013826a99/claude_agent_sdk-0.2.104-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:93c0c6ab71d2f30005fde6ad4dfdcfca4ba8ab2dee4e9ea03006d52a29450c8e", size = 72850797, upload-time = "2026-06-17T22:21:45.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7f/60e1ffe078c332bd5a17272ce7bdc00bf77eab6d03feb2018e050ca2b75b/claude_agent_sdk-0.2.104-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:ce65df9d28be9dd0bbe0998a57d095d33a3f7366727a8bb03a2fe5a53bbae768", size = 73824512, upload-time = "2026-06-17T22:21:50.674Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/02/74c5fc9241b7d77ba9bf5c14aff0db03c8b8f2eeb795c96cdd2668e6296e/claude_agent_sdk-0.2.104-py3-none-win_amd64.whl", hash = "sha256:e0e800f83be9a4b323eb52325373ab1a5e3da8b9824756b583223881bc42ebf2", size = 73570809, upload-time = "2026-06-17T22:21:56.078Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -555,6 +573,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "anthropic" },
+    { name = "claude-agent-sdk" },
     { name = "interrogate" },
     { name = "mypy" },
     { name = "pytest" },
@@ -575,6 +594,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.104" },
     { name = "interrogate", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pytest", specifier = ">=9.0.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.111.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/8a/9afc7305a2ce4b52b30e137f83cd2a6a90b918b3997073db11bb5a1de55a/anthropic-0.111.0.tar.gz", hash = "sha256:39cbda0ac17a6d423e5bf609811bd69b26eddf6299d7a468126e05bc711ce826", size = 934001, upload-time = "2026-06-18T17:31:44.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/bb/09e82a81885d787f350fb55ca9df865b63140dd28b3b5b3104c4ae261657/anthropic-0.111.0-py3-none-any.whl", hash = "sha256:c14edb36ed80da9099acbd26b5cec810d76606c31f32a0d56a4cf9d4fa9e25ae", size = 929774, upload-time = "2026-06-18T17:31:43.116Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -223,6 +242,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -345,6 +382,78 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -445,6 +554,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anthropic" },
     { name = "interrogate" },
     { name = "mypy" },
     { name = "pytest" },
@@ -464,6 +574,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anthropic", specifier = ">=0.40.0" },
     { name = "interrogate", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pytest", specifier = ">=9.0.3" },


### PR DESCRIPTION
## Summary

`update_category` could only change a category's name, note, or group — there was no way to set its recurring **monthly goal target** through the server (only the per-month *assigned* amount via `assign_money`). YNAB's category `PATCH` endpoint now accepts the goal fields, so this closes a pass-through gap.

`update_category` now accepts:
- `goal_target` — dollars, converted to milliunits (×1000)
- `goal_target_date` — ISO date string (e.g. `2026-07-01`)
- `goal_needs_whole_amount` — bool; NEED goals only ("Set Aside" vs. "Refill")

Mapped onto `ExistingCategory`, whose `exclude_none` serialization means omitted fields are never sent — partial updates can't clobber an existing goal, so no read-modify-write is needed. `assign_money` is left untouched.

## The dependency bump was not "minor"

Reaching these fields required bumping the `ynab` SDK from **1.0.1 → 4.1.0** (`goal_target_date` lands at 2.0.0, `goal_needs_whole_amount` at 4.1.0), verified by installing each release. That major bump carried two unavoidable migrations:

- **`budgets` → `plans` rename:** `BudgetsApi`/`get_budgets` → `PlansApi`/`get_plans`, `.data.budgets` → `.data.plans`. The public MCP tool `get_budgets` and `ynab://budgets` resource **keep their names** for client stability.
- **Strict `uuid.UUID` id fields:** coerced back to `str` where they cross into the str-typed prefs store / str-keyed cache (`_resolve_budget_id`) and the str-contract formatter (`_process_category_data`).

## Two latent crashes fixed (invisible to the old string-based mocks)

- `list_payees_resource` cached `payee.id` **raw**, but `Payee.id` is now `uuid.UUID` and the cache writer uses plain `json.dump` → `TypeError`. Now coerced to `str`.
- `_build_markdown_table` ran `len()`/format on raw cells; a `uuid.UUID` id cell raised `TypeError`. Cells are now `str`-coerced at the builder entry.

## LLM-driven eval suite (Code Mode)

Adds `evals/evals.json` + a harness/test (`tests/integration/`) that launches the server over **real MCP stdio**, lets **Claude** drive the **Code Mode** surface (`search` + `execute`), and scores answers with a hybrid gate: structural (engaged the Code Mode tools; never invoked a legacy write tool) + an **LLM judge** of the final answer.

- **Read-only by construction:** the server defaults to `code_mode_mutations_enabled=False`, so `ynab.write.*` is blocked server-side and hidden from the spec (verified: read-only `build_spec` exposes only the `read` namespace). Safe against a live budget.
- Gated behind a new `eval` marker + `ANTHROPIC_API_KEY`/`YNAB_API_KEY`; excluded from default and plain `integration` runs. `task test:eval` to run.
- Harness pure helpers have key-free unit tests in the default suite.
- ⚠️ End-to-end validation of the goal-target **write** is *not* possible read-only (writes are hidden in Code Mode); tracked as a follow-up gated write-eval.

## Tests

**330 passing (incl. new `update_category` goal tests, UUID regression tests pushing real `uuid.UUID`, and eval-harness unit tests); 9 LLM evals skip without keys; ruff clean.**

> Validated by unit tests + a Code-Mode stdio smoke check. The LLM evals and YNAB API paths have not been run against a live budget in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recurring monthly category goals, including target amounts and due dates.

* **Bug Fixes**
  * Fixed table formatting when handling non-string values.
  * Improved ID serialization consistency.

* **Tests**
  * Introduced LLM-driven evaluation suite for comprehensive testing.

* **Dependencies**
  * Updated YNAB SDK compatibility; added Anthropic and Claude Agent SDK support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->